### PR TITLE
feat(space, stock): Implement Stock Management for Colocation

### DIFF
--- a/co-habit-project/co-habit-application/src/main/resources/application.yml
+++ b/co-habit-project/co-habit-application/src/main/resources/application.yml
@@ -37,6 +37,9 @@ spring:
     uris:
       - http://localhost:9200
 
+elasticsearch:
+  enabled: false
+
 # Configuration CORS
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:*}

--- a/co-habit-project/co-habit-domain/src/main/java/fr/esgi/domain/dto/space/StockItemReqDto.java
+++ b/co-habit-project/co-habit-domain/src/main/java/fr/esgi/domain/dto/space/StockItemReqDto.java
@@ -1,0 +1,28 @@
+package fr.esgi.domain.dto.space;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@SuperBuilder
+@Schema(description = "Requête de création/modification d'un item de stock")
+public class StockItemReqDto {
+
+    @NotBlank(message = "Le nom de l'item est requis")
+    @Size(min = 2, max = 100, message = "Le nom doit contenir entre 2 et 100 caractères")
+    @Schema(description = "Nom de l'item", example = "Lait")
+    private String name;
+
+    @NotNull(message = "La quantité est requise")
+    @Min(value = 0, message = "La quantité ne peut pas être négative")
+    @Schema(description = "Quantité de l'item", example = "2")
+    private Integer quantity;
+}

--- a/co-habit-project/co-habit-domain/src/main/java/fr/esgi/domain/dto/space/StockItemResDto.java
+++ b/co-habit-project/co-habit-domain/src/main/java/fr/esgi/domain/dto/space/StockItemResDto.java
@@ -1,0 +1,29 @@
+package fr.esgi.domain.dto.space;
+
+import fr.esgi.domain.dto.user.UserProfileResDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@SuperBuilder
+@Schema(description = "Réponse d'un item de stock")
+public class StockItemResDto extends StockItemReqDto {
+
+    @Schema(description = "Identifiant unique de l'item", example = "1")
+    private Long id;
+
+    @Schema(description = "Utilisateur qui a ajouté l'item")
+    private UserProfileResDto addedBy;
+
+    public StockItemResDto(Long id, String name, Integer quantity) {
+        super(name, quantity);
+        this.id = id;
+    }
+}

--- a/co-habit-project/co-habit-domain/src/main/java/fr/esgi/domain/dto/space/StockReqDto.java
+++ b/co-habit-project/co-habit-domain/src/main/java/fr/esgi/domain/dto/space/StockReqDto.java
@@ -1,0 +1,42 @@
+package fr.esgi.domain.dto.space;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@SuperBuilder
+@Schema(description = "Requête de création/modification d'un stock")
+public class StockReqDto {
+
+    @NotBlank(message = "Le titre est requis")
+    @Size(min = 2, max = 100, message = "Le titre doit contenir entre 2 et 100 caractères")
+    @Schema(description = "Titre du stock", example = "Frigo")
+    private String title;
+
+    @Schema(description = "Image du stock", example = "fridge.png")
+    private String imageAsset;
+
+    @Schema(description = "Couleur du stock", example = "#FF5733")
+    private String color;
+
+    @Min(value = 1, message = "La capacité maximale doit être d'au moins 1")
+    @Max(value = 1000, message = "La capacité maximale ne peut pas dépasser 1000")
+    @Schema(description = "Capacité maximale du stock", example = "50")
+    private Integer maxCapacity;
+
+    public StockReqDto(String title, String description) {
+        this.title = title;
+        // Note: assuming description is mapped to a different field or removed
+    }
+}

--- a/co-habit-project/co-habit-domain/src/main/java/fr/esgi/domain/dto/space/StockResDto.java
+++ b/co-habit-project/co-habit-domain/src/main/java/fr/esgi/domain/dto/space/StockResDto.java
@@ -1,0 +1,29 @@
+package fr.esgi.domain.dto.space;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@SuperBuilder
+@Schema(description = "Réponse d'un stock")
+public class StockResDto extends StockReqDto {
+
+    @Schema(description = "Identifiant unique du stock", example = "1")
+    private Long id;
+
+    @Schema(description = "Nombre d'items dans le stock", example = "5")
+    private Integer itemCount;
+
+    public StockResDto(Long id, String title, String description, Integer itemCount) {
+        super(title, description);
+        this.id        = id;
+        this.itemCount = itemCount;
+    }
+}

--- a/co-habit-project/co-habit-persistence/src/main/java/fr/esgi/persistence/document/TaskDocument.java
+++ b/co-habit-project/co-habit-persistence/src/main/java/fr/esgi/persistence/document/TaskDocument.java
@@ -19,52 +19,55 @@ import java.util.Set;
 @AllArgsConstructor
 @Builder
 public class TaskDocument {
-    
+
     @Id
     private String id;
-    
+
     @Field(type = FieldType.Long)
     private Long userId;
-    
+
     @Field(type = FieldType.Keyword)
     private String userKeycloakSub;
-    
+
     @Field(type = FieldType.Text, name = "user_name")
     private String userName;
-    
+
     @Field(type = FieldType.Long)
     private Long colocationId;
-    
+
     @Field(type = FieldType.Text, name = "colocation_name")
     private String colocationName;
-    
+
     @Field(type = FieldType.Text)
     private String title;
-    
+
     @Field(type = FieldType.Text)
     private String description;
-    
+
     @Field(type = FieldType.Keyword)
     private TaskStatus status;
-    
+
     @Field(type = FieldType.Keyword)
     private TaskPriority priority;
-    
+
     @Field(type = FieldType.Date, name = "created_at")
     private LocalDateTime createdAt;
-    
+
     @Field(type = FieldType.Date, name = "due_date")
     private LocalDate dueDate;
-    
+
     @Field(type = FieldType.Date, name = "completed_at")
     private LocalDateTime completedAt;
-    
+
     @Field(type = FieldType.Long, name = "creator_id")
     private Long creatorId;
 
     @Field(type = FieldType.Long)
     private Set<Long> assignedUserIds;
-    
+
+    @Field(type = FieldType.Keyword, name = "assigned_to_user_keycloak_subs")
+    private Set<String> assignedToUserKeycloakSubs;
+
     @Field(type = FieldType.Keyword)
     private Set<String> tags;
 }

--- a/co-habit-project/co-habit-persistence/src/main/java/fr/esgi/persistence/entity/space/Colocation.java
+++ b/co-habit-project/co-habit-persistence/src/main/java/fr/esgi/persistence/entity/space/Colocation.java
@@ -7,7 +7,9 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -16,89 +18,104 @@ import java.util.Set;
 @Setter
 @NoArgsConstructor
 public class Colocation {
-    
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    
+
     @Column(nullable = false)
     private String name;
-    
+
     private String description;
-    
+
     @Column(nullable = false)
     private String address;
-    
+
     private String city;
-    
+
     private String postalCode;
 
     @Column(name = "invitation_code", unique = true)
     private String invitationCode;
-    
+
     @Column(name = "max_roommates")
     private Integer maxRoommates;
-    
+
     @Column(name = "created_at")
     private LocalDateTime createdAt;
-    
+
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
-    
+
     // Gestionnaire de la colocation (propriétaire/administrateur)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "manager_id", nullable = false)
     private User manager;
-    
+
     // Liste des colocataires (relation Many-to-Many)
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
-        name = "colocation_roommates",
-        joinColumns = @JoinColumn(name = "colocation_id"),
-        inverseJoinColumns = @JoinColumn(name = "user_id")
+            name = "colocation_roommates",
+            joinColumns = @JoinColumn(name = "colocation_id"),
+            inverseJoinColumns = @JoinColumn(name = "user_id")
     )
     private Set<User> roommates = new HashSet<>();
-    
+
+    // Liste des stocks de la colocation
+    @OneToMany(mappedBy = "colocation", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<StockEntity> stocks = new ArrayList<>();
+
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();
         updatedAt = LocalDateTime.now();
     }
-    
+
     @PreUpdate
     protected void onUpdate() {
         updatedAt = LocalDateTime.now();
     }
-    
+
     public Colocation(String name, String address, User manager) {
-        this.name = name;
+        this.name    = name;
         this.address = address;
         this.manager = manager;
         this.roommates.add(manager); // Le manager est automatiquement ajouté comme colocataire
     }
-    
+
     // Méthodes utilitaires pour gérer les colocataires
     public void addRoommate(User user) {
         roommates.add(user);
     }
-    
+
     public void removeRoommate(User user) {
         roommates.remove(user);
     }
-    
+
     public boolean isManager(User user) {
         return manager != null && manager.equals(user);
     }
-    
+
     public boolean isRoommate(User user) {
         return roommates.contains(user);
     }
-    
+
     public boolean isFull() {
         return maxRoommates != null && roommates.size() >= maxRoommates;
     }
-    
+
     public int getCurrentRoommatesCount() {
         return roommates.size();
+    }
+
+    // Méthodes utilitaires pour gérer les stocks
+    public void addStock(StockEntity stock) {
+        stocks.add(stock);
+        stock.setColocation(this);
+    }
+
+    public void removeStock(StockEntity stock) {
+        stocks.remove(stock);
+        stock.setColocation(null);
     }
 }

--- a/co-habit-project/co-habit-persistence/src/main/java/fr/esgi/persistence/entity/space/StockEntity.java
+++ b/co-habit-project/co-habit-persistence/src/main/java/fr/esgi/persistence/entity/space/StockEntity.java
@@ -1,0 +1,64 @@
+package fr.esgi.persistence.entity.space;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "stocks")
+@Getter
+@Setter
+@NoArgsConstructor
+public class StockEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    private String color;
+
+    @Column(name = "image_asset")
+    private String imageAsset;
+
+    @Column(name = "max_capacity")
+    private Integer maxCapacity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "colocation_id", nullable = false)
+    private Colocation colocation;
+
+    @OneToMany(mappedBy = "stock", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<StockItemEntity> items = new ArrayList<>();
+
+    public StockEntity(String title, Colocation colocation) {
+        this.title      = title;
+        this.colocation = colocation;
+    }
+
+    public void addItem(StockItemEntity item) {
+        items.add(item);
+        item.setStock(this);
+    }
+
+    public void removeItem(StockItemEntity item) {
+        items.remove(item);
+        item.setStock(null);
+    }
+
+    public int getCurrentItemsCount() {
+        return items.stream()
+                    .mapToInt(StockItemEntity::getQuantity)
+                    .sum();
+    }
+
+    public boolean isAtCapacity() {
+        return maxCapacity != null && getCurrentItemsCount() >= maxCapacity;
+    }
+}

--- a/co-habit-project/co-habit-persistence/src/main/java/fr/esgi/persistence/entity/space/StockItemEntity.java
+++ b/co-habit-project/co-habit-persistence/src/main/java/fr/esgi/persistence/entity/space/StockItemEntity.java
@@ -1,0 +1,62 @@
+package fr.esgi.persistence.entity.space;
+
+import fr.esgi.persistence.entity.user.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "stock_items")
+@Getter
+@Setter
+@NoArgsConstructor
+public class StockItemEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Integer quantity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stock_id", nullable = false)
+    private StockEntity stock;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "added_by", nullable = false)
+    private User addedBy;
+
+    @Column(name = "added_at")
+    private LocalDateTime addedAt;
+
+    public StockItemEntity(String name, Integer quantity) {
+        this.name     = name;
+        this.quantity = quantity;
+    }
+
+    public StockItemEntity(String name, Integer quantity, User addedBy) {
+        this.name     = name;
+        this.quantity = quantity;
+        this.addedBy  = addedBy;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        addedAt = LocalDateTime.now();
+    }
+
+    public void increaseQuantity(int amount) {
+        this.quantity += amount;
+    }
+
+    public void decreaseQuantity(int amount) {
+        this.quantity = Math.max(0, this.quantity - amount);
+    }
+}

--- a/co-habit-project/co-habit-persistence/src/main/java/fr/esgi/persistence/repository/space/StockItemRepository.java
+++ b/co-habit-project/co-habit-persistence/src/main/java/fr/esgi/persistence/repository/space/StockItemRepository.java
@@ -1,0 +1,50 @@
+package fr.esgi.persistence.repository.space;
+
+import fr.esgi.persistence.entity.space.StockItemEntity;
+import fr.esgi.persistence.entity.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface StockItemRepository extends JpaRepository<StockItemEntity, Long> {
+
+    List<StockItemEntity> findByStockId(Long stockId);
+
+    Optional<StockItemEntity> findByIdAndStockId(Long id, Long stockId);
+
+    List<StockItemEntity> findByNameContainingIgnoreCaseAndStockId(String name, Long stockId);
+
+    @Query("SELECT si FROM StockItemEntity si WHERE si.stock.id = :stockId AND si.quantity > 0")
+    List<StockItemEntity> findAvailableItemsByStockId(@Param("stockId") Long stockId);
+
+    @Query("SELECT si FROM StockItemEntity si WHERE si.stock.id = :stockId AND si.quantity = 0")
+    List<StockItemEntity> findOutOfStockItemsByStockId(@Param("stockId") Long stockId);
+
+    @Query("SELECT si FROM StockItemEntity si WHERE si.stock.colocation.id = :colocationId")
+    List<StockItemEntity> findByColocationId(@Param("colocationId") Long colocationId);
+
+    @Query("SELECT si FROM StockItemEntity si WHERE si.stock.colocation.id = :colocationId AND si.name LIKE %:name%")
+    List<StockItemEntity> findByNameContainingAndColocationId(@Param("name") String name, @Param("colocationId") Long colocationId);
+
+    @Query("SELECT SUM(si.quantity) FROM StockItemEntity si WHERE si.stock.id = :stockId")
+    Integer getTotalQuantityByStockId(@Param("stockId") Long stockId);
+
+    boolean existsByNameAndStockId(String name, Long stockId);
+
+    List<StockItemEntity> findByAddedBy(User user);
+
+    List<StockItemEntity> findByStockIdAndAddedBy(Long stockId, User user);
+
+    @Query("SELECT si FROM StockItemEntity si WHERE si.stock.colocation.id = :colocationId AND si.addedBy = :user")
+    List<StockItemEntity> findByColocationIdAndAddedBy(@Param("colocationId") Long colocationId, @Param("user") User user);
+
+    @Query("SELECT COUNT(si) FROM StockItemEntity si WHERE si.addedBy = :user")
+    Long countByAddedBy(@Param("user") User user);
+
+    void deleteByIdAndStockId(Long id, Long stockId);
+}

--- a/co-habit-project/co-habit-persistence/src/main/java/fr/esgi/persistence/repository/space/StockRepository.java
+++ b/co-habit-project/co-habit-persistence/src/main/java/fr/esgi/persistence/repository/space/StockRepository.java
@@ -1,0 +1,30 @@
+package fr.esgi.persistence.repository.space;
+
+import fr.esgi.persistence.entity.space.StockEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface StockRepository extends JpaRepository<StockEntity, Long> {
+
+    List<StockEntity> findByColocationId(Long colocationId);
+
+    Optional<StockEntity> findByIdAndColocationId(Long id, Long colocationId);
+
+    List<StockEntity> findByTitleContainingIgnoreCaseAndColocationId(String title, Long colocationId);
+
+    @Query("SELECT s FROM StockEntity s WHERE s.colocation.id = :colocationId AND s.maxCapacity IS NOT NULL")
+    List<StockEntity> findStocksWithCapacityByColocationId(@Param("colocationId") Long colocationId);
+
+    @Query("SELECT s FROM StockEntity s WHERE s.colocation.id = :colocationId AND s.color = :color")
+    List<StockEntity> findByColocationIdAndColor(@Param("colocationId") Long colocationId, @Param("color") String color);
+
+    boolean existsByTitleAndColocationId(String title, Long colocationId);
+
+    void deleteByIdAndColocationId(Long id, Long colocationId);
+}

--- a/co-habit-project/co-habit-persistence/src/main/java/fr/esgi/persistence/repository/task/TaskRepository.java
+++ b/co-habit-project/co-habit-persistence/src/main/java/fr/esgi/persistence/repository/task/TaskRepository.java
@@ -15,7 +15,7 @@ public interface TaskRepository extends ElasticsearchRepository<TaskDocument, St
     
     List<TaskDocument> findByColocationIdAndStatus(Long colocationId, String status);
     
-    List<TaskDocument> findByAssignedToUserKeycloakSub(String assignedToUserKeycloakSub);
+    List<TaskDocument> findByAssignedToUserKeycloakSubs(String assignedToUserKeycloakSub);
     
-    List<TaskDocument> findByColocationIdAndAssignedToUserKeycloakSub(Long colocationId, String userKeycloakSub);
+    List<TaskDocument> findByColocationIdAndAssignedToUserKeycloakSubs(Long colocationId, String userKeycloakSub);
 }

--- a/co-habit-project/co-habit-persistence/src/test/java/fr/esgi/persistence/repository/space/StockItemRepositoryTest.java
+++ b/co-habit-project/co-habit-persistence/src/test/java/fr/esgi/persistence/repository/space/StockItemRepositoryTest.java
@@ -1,0 +1,275 @@
+package fr.esgi.persistence.repository.space;
+
+import fr.esgi.persistence.entity.space.Colocation;
+import fr.esgi.persistence.entity.space.StockEntity;
+import fr.esgi.persistence.entity.space.StockItemEntity;
+import fr.esgi.persistence.entity.user.User;
+import fr.esgi.persistence.repository.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class StockItemRepositoryTest {
+
+    @Autowired
+    private StockItemRepository stockItemRepository;
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @Autowired
+    private ColocationRepository colocationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User            manager;
+    private Colocation      colocation;
+    private StockEntity     fridgeStock;
+    private StockEntity     pantryStock;
+    private StockItemEntity milk;
+    private StockItemEntity eggs;
+    private StockItemEntity emptyItem;
+    private StockItemEntity rice;
+
+    @BeforeEach
+    void setUp() {
+        manager = new User();
+        manager.setFirstName("Jean");
+        manager.setLastName("Dupont");
+        manager.setEmail("jean.dupont@test.com");
+        manager.setUsername("jeandupont");
+        manager.setKeyCloakSub("manager-keycloak-id");
+        manager = userRepository.save(manager);
+
+        colocation = new Colocation();
+        colocation.setName("Appartement Centre-ville");
+        colocation.setAddress("123 Rue de la Paix");
+        colocation.setManager(manager);
+        colocation = colocationRepository.save(colocation);
+
+        fridgeStock = new StockEntity();
+        fridgeStock.setTitle("Frigo");
+        fridgeStock.setColocation(colocation);
+        fridgeStock = stockRepository.save(fridgeStock);
+
+        pantryStock = new StockEntity();
+        pantryStock.setTitle("Garde-manger");
+        pantryStock.setColocation(colocation);
+        pantryStock = stockRepository.save(pantryStock);
+
+        // Création des items avec addedBy
+        milk = new StockItemEntity("Lait", 2, manager);
+        milk.setStock(fridgeStock);
+        milk = stockItemRepository.save(milk);
+
+        eggs = new StockItemEntity("Œufs", 12, manager);
+        eggs.setStock(fridgeStock);
+        eggs = stockItemRepository.save(eggs);
+
+        emptyItem = new StockItemEntity("Beurre", 0, manager);
+        emptyItem.setStock(fridgeStock);
+        emptyItem = stockItemRepository.save(emptyItem);
+
+        rice = new StockItemEntity("Riz", 5, manager);
+        rice.setStock(pantryStock);
+        rice = stockItemRepository.save(rice);
+    }
+
+    @Test
+    void testSaveAndFindStockItem() {
+        Optional<StockItemEntity> found = stockItemRepository.findById(milk.getId());
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getName()).isEqualTo("Lait");
+        assertThat(found.get().getQuantity()).isEqualTo(2);
+        assertThat(found.get().getStock()).isEqualTo(fridgeStock);
+        assertThat(found.get().getAddedBy()).isEqualTo(manager);
+        assertThat(found.get().getAddedAt()).isNotNull();
+    }
+
+    @Test
+    void testFindByStockId() {
+        List<StockItemEntity> fridgeItems = stockItemRepository.findByStockId(fridgeStock.getId());
+
+        assertThat(fridgeItems).hasSize(3);
+        assertThat(fridgeItems).contains(milk, eggs, emptyItem);
+
+        List<StockItemEntity> pantryItems = stockItemRepository.findByStockId(pantryStock.getId());
+        assertThat(pantryItems).hasSize(1);
+        assertThat(pantryItems).contains(rice);
+    }
+
+    @Test
+    void testFindByIdAndStockId() {
+        Optional<StockItemEntity> found = stockItemRepository.findByIdAndStockId(milk.getId(), fridgeStock.getId());
+
+        assertThat(found).isPresent();
+        assertThat(found.get()).isEqualTo(milk);
+
+        // Test avec un stock différent
+        Optional<StockItemEntity> notFound = stockItemRepository.findByIdAndStockId(milk.getId(), pantryStock.getId());
+        assertThat(notFound).isEmpty();
+    }
+
+    @Test
+    void testFindByNameContainingIgnoreCaseAndStockId() {
+        List<StockItemEntity> items = stockItemRepository.findByNameContainingIgnoreCaseAndStockId("lai", fridgeStock.getId());
+
+        assertThat(items).hasSize(1);
+        assertThat(items.get(0)).isEqualTo(milk);
+
+        // Test insensible à la casse
+        items = stockItemRepository.findByNameContainingIgnoreCaseAndStockId("ŒUFS", fridgeStock.getId());
+        assertThat(items).hasSize(1);
+        assertThat(items.get(0)).isEqualTo(eggs);
+    }
+
+    @Test
+    void testFindAvailableItemsByStockId() {
+        List<StockItemEntity> availableItems = stockItemRepository.findAvailableItemsByStockId(fridgeStock.getId());
+
+        assertThat(availableItems).hasSize(2);
+        assertThat(availableItems).contains(milk, eggs);
+        assertThat(availableItems).doesNotContain(emptyItem);
+    }
+
+    @Test
+    void testFindOutOfStockItemsByStockId() {
+        List<StockItemEntity> outOfStockItems = stockItemRepository.findOutOfStockItemsByStockId(fridgeStock.getId());
+
+        assertThat(outOfStockItems).hasSize(1);
+        assertThat(outOfStockItems).contains(emptyItem);
+        assertThat(outOfStockItems).doesNotContain(milk, eggs);
+    }
+
+    @Test
+    void testFindByColocationId() {
+        List<StockItemEntity> allItems = stockItemRepository.findByColocationId(colocation.getId());
+
+        assertThat(allItems).hasSize(4);
+        assertThat(allItems).contains(milk, eggs, emptyItem, rice);
+    }
+
+    @Test
+    void testFindByNameContainingAndColocationId() {
+        List<StockItemEntity> items = stockItemRepository.findByNameContainingAndColocationId("i", colocation.getId());
+
+        // Items contenant "i": Lait, Riz
+        assertThat(items).hasSize(2);
+        assertThat(items).contains(milk, rice);
+    }
+
+    @Test
+    void testGetTotalQuantityByStockId() {
+        Integer totalQuantity = stockItemRepository.getTotalQuantityByStockId(fridgeStock.getId());
+
+        // Lait: 2, Œufs: 12, Beurre: 0 = 14 total
+        assertThat(totalQuantity).isEqualTo(14);
+
+        Integer pantryQuantity = stockItemRepository.getTotalQuantityByStockId(pantryStock.getId());
+        assertThat(pantryQuantity).isEqualTo(5);
+    }
+
+    @Test
+    void testExistsByNameAndStockId() {
+        boolean exists = stockItemRepository.existsByNameAndStockId("Lait", fridgeStock.getId());
+        assertThat(exists).isTrue();
+
+        boolean notExists = stockItemRepository.existsByNameAndStockId("Fromage", fridgeStock.getId());
+        assertThat(notExists).isFalse();
+
+        // Test dans un autre stock
+        boolean existsInPantry = stockItemRepository.existsByNameAndStockId("Lait", pantryStock.getId());
+        assertThat(existsInPantry).isFalse();
+    }
+
+    @Test
+    void testStockItemUtilityMethods() {
+        // Test increase quantity
+        int initialQuantity = milk.getQuantity();
+        milk.increaseQuantity(3);
+        assertThat(milk.getQuantity()).isEqualTo(initialQuantity + 3);
+
+        // Test decrease quantity
+        milk.decreaseQuantity(2);
+        assertThat(milk.getQuantity()).isEqualTo(initialQuantity + 1);
+
+        // Test decrease below zero
+        milk.decreaseQuantity(10);
+        assertThat(milk.getQuantity()).isEqualTo(0);
+    }
+
+    @Test
+    void testDeleteByIdAndStockId() {
+        Long itemId  = milk.getId();
+        Long stockId = fridgeStock.getId();
+
+        stockItemRepository.deleteByIdAndStockId(itemId, stockId);
+
+        Optional<StockItemEntity> deleted = stockItemRepository.findById(itemId);
+        assertThat(deleted).isEmpty();
+
+        // Vérifier que les autres items existent encore
+        List<StockItemEntity> remainingItems = stockItemRepository.findByStockId(stockId);
+        assertThat(remainingItems).hasSize(2);
+        assertThat(remainingItems).contains(eggs, emptyItem);
+    }
+
+    @Test
+    void testCreateItemWithConstructor() {
+        StockItemEntity newItem = new StockItemEntity("Yaourt", 6);
+
+        assertThat(newItem.getName()).isEqualTo("Yaourt");
+        assertThat(newItem.getQuantity()).isEqualTo(6);
+        assertThat(newItem.getStock()).isNull();
+    }
+
+    @Test
+    void testFindByAddedBy() {
+        List<StockItemEntity> itemsByManager = stockItemRepository.findByAddedBy(manager);
+
+        assertThat(itemsByManager).hasSize(4);
+        assertThat(itemsByManager).contains(milk, eggs, emptyItem, rice);
+    }
+
+    @Test
+    void testFindByStockIdAndAddedBy() {
+        List<StockItemEntity> fridgeItemsByManager = stockItemRepository.findByStockIdAndAddedBy(fridgeStock.getId(), manager);
+
+        assertThat(fridgeItemsByManager).hasSize(3);
+        assertThat(fridgeItemsByManager).contains(milk, eggs, emptyItem);
+    }
+
+    @Test
+    void testFindByColocationIdAndAddedBy() {
+        List<StockItemEntity> itemsByManagerInColocation = stockItemRepository.findByColocationIdAndAddedBy(colocation.getId(), manager);
+
+        assertThat(itemsByManagerInColocation).hasSize(4);
+        assertThat(itemsByManagerInColocation).contains(milk, eggs, emptyItem, rice);
+    }
+
+    @Test
+    void testCountByAddedBy() {
+        Long count = stockItemRepository.countByAddedBy(manager);
+
+        assertThat(count).isEqualTo(4);
+    }
+
+    @Test
+    void testCreateItemWithConstructorAndAddedBy() {
+        StockItemEntity newItem = new StockItemEntity("Yaourt", 6, manager);
+        
+        assertThat(newItem.getName()).isEqualTo("Yaourt");
+        assertThat(newItem.getQuantity()).isEqualTo(6);
+        assertThat(newItem.getAddedBy()).isEqualTo(manager);
+        assertThat(newItem.getStock()).isNull();
+    }
+}

--- a/co-habit-project/co-habit-persistence/src/test/java/fr/esgi/persistence/repository/space/StockRepositoryTest.java
+++ b/co-habit-project/co-habit-persistence/src/test/java/fr/esgi/persistence/repository/space/StockRepositoryTest.java
@@ -1,0 +1,204 @@
+package fr.esgi.persistence.repository.space;
+
+import fr.esgi.persistence.entity.space.Colocation;
+import fr.esgi.persistence.entity.space.StockEntity;
+import fr.esgi.persistence.entity.space.StockItemEntity;
+import fr.esgi.persistence.entity.user.User;
+import fr.esgi.persistence.repository.user.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class StockRepositoryTest {
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @Autowired
+    private ColocationRepository colocationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User        manager;
+    private Colocation  colocation;
+    private StockEntity fridgeStock;
+    private StockEntity pantryStock;
+    private StockEntity cleaningStock;
+
+    @BeforeEach
+    void setUp() {
+        manager = new User();
+        manager.setFirstName("Jean");
+        manager.setLastName("Dupont");
+        manager.setEmail("jean.dupont@test.com");
+        manager.setUsername("jeandupont");
+        manager.setKeyCloakSub("manager-keycloak-id");
+        manager = userRepository.save(manager);
+
+        colocation = new Colocation();
+        colocation.setName("Appartement Centre-ville");
+        colocation.setAddress("123 Rue de la Paix");
+        colocation.setCity("Paris");
+        colocation.setManager(manager);
+        colocation = colocationRepository.save(colocation);
+
+        // Création des stocks
+        fridgeStock = new StockEntity();
+        fridgeStock.setTitle("Frigo");
+        fridgeStock.setColor("#00FF00");
+        fridgeStock.setImageAsset("fridge.png");
+        fridgeStock.setMaxCapacity(50);
+        fridgeStock.setColocation(colocation);
+        fridgeStock = stockRepository.save(fridgeStock);
+
+        pantryStock = new StockEntity();
+        pantryStock.setTitle("Garde-manger");
+        pantryStock.setColor("#FFFF00");
+        pantryStock.setImageAsset("pantry.png");
+        pantryStock.setMaxCapacity(100);
+        pantryStock.setColocation(colocation);
+        pantryStock = stockRepository.save(pantryStock);
+
+        cleaningStock = new StockEntity();
+        cleaningStock.setTitle("Produits de nettoyage");
+        cleaningStock.setColor("#FF0000");
+        cleaningStock.setImageAsset("cleaning.png");
+        cleaningStock.setColocation(colocation);
+        cleaningStock = stockRepository.save(cleaningStock);
+    }
+
+    @Test
+    void testSaveAndFindStock() {
+        Optional<StockEntity> found = stockRepository.findById(fridgeStock.getId());
+
+        assertThat(found).isPresent();
+        assertThat(found.get()
+                        .getTitle()).isEqualTo("Frigo");
+        assertThat(found.get()
+                        .getColor()).isEqualTo("#00FF00");
+        assertThat(found.get()
+                        .getMaxCapacity()).isEqualTo(50);
+        assertThat(found.get()
+                        .getColocation()).isEqualTo(colocation);
+    }
+
+    @Test
+    void testFindByColocationId() {
+        List<StockEntity> stocks = stockRepository.findByColocationId(colocation.getId());
+
+        assertThat(stocks).hasSize(3);
+        assertThat(stocks).contains(fridgeStock, pantryStock, cleaningStock);
+    }
+
+    @Test
+    void testFindByIdAndColocationId() {
+        Optional<StockEntity> found = stockRepository.findByIdAndColocationId(fridgeStock.getId(), colocation.getId());
+
+        assertThat(found).isPresent();
+        assertThat(found.get()).isEqualTo(fridgeStock);
+
+        // Test avec une colocation inexistante
+        Optional<StockEntity> notFound = stockRepository.findByIdAndColocationId(fridgeStock.getId(), 999L);
+        assertThat(notFound).isEmpty();
+    }
+
+    @Test
+    void testFindByTitleContainingIgnoreCaseAndColocationId() {
+        List<StockEntity> stocks = stockRepository.findByTitleContainingIgnoreCaseAndColocationId("frigo", colocation.getId());
+
+        assertThat(stocks).hasSize(1);
+        assertThat(stocks.get(0)).isEqualTo(fridgeStock);
+
+        // Test insensible à la casse
+        stocks = stockRepository.findByTitleContainingIgnoreCaseAndColocationId("GARDE", colocation.getId());
+        assertThat(stocks).hasSize(1);
+        assertThat(stocks.get(0)).isEqualTo(pantryStock);
+    }
+
+    @Test
+    void testFindStocksWithCapacityByColocationId() {
+        List<StockEntity> stocksWithCapacity = stockRepository.findStocksWithCapacityByColocationId(colocation.getId());
+
+        assertThat(stocksWithCapacity).hasSize(2);
+        assertThat(stocksWithCapacity).contains(fridgeStock, pantryStock);
+        assertThat(stocksWithCapacity).doesNotContain(cleaningStock);
+    }
+
+    @Test
+    void testFindByColocationIdAndColor() {
+        List<StockEntity> greenStocks = stockRepository.findByColocationIdAndColor(colocation.getId(), "#00FF00");
+
+        assertThat(greenStocks).hasSize(1);
+        assertThat(greenStocks.get(0)).isEqualTo(fridgeStock);
+
+        List<StockEntity> blueStocks = stockRepository.findByColocationIdAndColor(colocation.getId(), "#0000FF");
+        assertThat(blueStocks).isEmpty();
+    }
+
+    @Test
+    void testExistsByTitleAndColocationId() {
+        boolean exists = stockRepository.existsByTitleAndColocationId("Frigo", colocation.getId());
+        assertThat(exists).isTrue();
+
+        boolean notExists = stockRepository.existsByTitleAndColocationId("Cave à vin", colocation.getId());
+        assertThat(notExists).isFalse();
+    }
+
+    @Test
+    void testStockUtilityMethods() {
+        // Test des méthodes utilitaires
+        assertThat(fridgeStock.getCurrentItemsCount()).isEqualTo(0);
+        assertThat(fridgeStock.isAtCapacity()).isFalse();
+
+        // Ajout d'items pour tester
+        StockItemEntity item1 = new StockItemEntity("Lait", 2);
+        StockItemEntity item2 = new StockItemEntity("Œufs", 12);
+
+        fridgeStock.addItem(item1);
+        fridgeStock.addItem(item2);
+
+        assertThat(fridgeStock.getCurrentItemsCount()).isEqualTo(14);
+        assertThat(fridgeStock.isAtCapacity()).isFalse();
+
+        // Test avec stock sans capacité max
+        assertThat(cleaningStock.isAtCapacity()).isFalse();
+    }
+
+    @Test
+    void testAddAndRemoveItems() {
+        StockItemEntity item = new StockItemEntity("Yaourt", 6);
+
+        pantryStock.addItem(item);
+        assertThat(pantryStock.getItems()).hasSize(1);
+        assertThat(pantryStock.getItems()).contains(item);
+        assertThat(item.getStock()).isEqualTo(pantryStock);
+
+        pantryStock.removeItem(item);
+        assertThat(pantryStock.getItems()).isEmpty();
+        assertThat(item.getStock()).isNull();
+    }
+
+    @Test
+    void testDeleteByIdAndColocationId() {
+        Long stockId      = fridgeStock.getId();
+        Long colocationId = colocation.getId();
+
+        stockRepository.deleteByIdAndColocationId(stockId, colocationId);
+
+        Optional<StockEntity> deleted = stockRepository.findById(stockId);
+        assertThat(deleted).isEmpty();
+
+        // Vérifier que les autres stocks existent encore
+        List<StockEntity> remainingStocks = stockRepository.findByColocationId(colocationId);
+        assertThat(remainingStocks).hasSize(2);
+        assertThat(remainingStocks).contains(pantryStock, cleaningStock);
+    }
+}

--- a/co-habit-project/co-habit-rest/src/main/java/fr/esgi/rest/interne/StockRest.java
+++ b/co-habit-project/co-habit-rest/src/main/java/fr/esgi/rest/interne/StockRest.java
@@ -1,0 +1,207 @@
+package fr.esgi.rest.interne;
+
+import fr.esgi.domain.dto.space.StockItemReqDto;
+import fr.esgi.domain.dto.space.StockItemResDto;
+import fr.esgi.domain.dto.space.StockReqDto;
+import fr.esgi.domain.dto.space.StockResDto;
+import fr.esgi.domain.exception.TechnicalException;
+import fr.esgi.service.space.StockService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/interne/colocations/{colocationId}/stocks")
+@RequiredArgsConstructor
+@Tag(name = "Stock", description = "API de gestion des stocks")
+public class StockRest {
+
+    private final StockService stockService;
+
+    @PostMapping
+    @Operation(summary = "Créer un nouveau stock", description = "Crée un nouveau stock dans une colocation")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "201", description = "Stock créé avec succès"),
+                    @ApiResponse(responseCode = "400", description = "Données invalides"),
+                    @ApiResponse(responseCode = "401", description = "Utilisateur non authentifié"),
+                    @ApiResponse(responseCode = "403", description = "Accès refusé - vous devez être membre de la colocation"),
+                    @ApiResponse(responseCode = "404", description = "Colocation non trouvée"),
+                    @ApiResponse(responseCode = "409", description = "Un stock avec ce titre existe déjà")
+            }
+    )
+    public ResponseEntity<StockResDto> createStock(
+            @Parameter(description = "ID de la colocation") @PathVariable Long colocationId,
+            @Valid @RequestBody StockReqDto dto) throws
+                                                 TechnicalException {
+        StockResDto result = stockService.createStock(colocationId, dto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                             .body(result);
+    }
+
+    @PutMapping("/{stockId}")
+    @Operation(summary = "Modifier un stock", description = "Modifie un stock existant")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Stock modifié avec succès"),
+                    @ApiResponse(responseCode = "400", description = "Données invalides"),
+                    @ApiResponse(responseCode = "401", description = "Utilisateur non authentifié"),
+                    @ApiResponse(responseCode = "403", description = "Accès refusé - vous devez être membre de la colocation"),
+                    @ApiResponse(responseCode = "404", description = "Stock ou colocation non trouvé(e)")
+            }
+    )
+    public ResponseEntity<StockResDto> updateStock(
+            @Parameter(description = "ID de la colocation") @PathVariable Long colocationId,
+            @Parameter(description = "ID du stock") @PathVariable Long stockId,
+            @Valid @RequestBody StockReqDto dto) throws
+                                                 TechnicalException {
+        StockResDto result = stockService.updateStock(colocationId, stockId, dto);
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping
+    @Operation(summary = "Obtenir tous les stocks", description = "Récupère tous les stocks d'une colocation")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Liste des stocks"),
+                    @ApiResponse(responseCode = "401", description = "Utilisateur non authentifié"),
+                    @ApiResponse(responseCode = "403", description = "Accès refusé - vous devez être membre de la colocation"),
+                    @ApiResponse(responseCode = "404", description = "Colocation non trouvée")
+            }
+    )
+    public ResponseEntity<List<StockResDto>> getStocksByColocation(
+            @Parameter(description = "ID de la colocation") @PathVariable Long colocationId) throws
+                                                                                             TechnicalException {
+        List<StockResDto> result = stockService.getStocksByColocation(colocationId);
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{stockId}")
+    @Operation(summary = "Obtenir un stock par ID", description = "Récupère un stock spécifique par son identifiant")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Stock trouvé"),
+                    @ApiResponse(responseCode = "401", description = "Utilisateur non authentifié"),
+                    @ApiResponse(responseCode = "403", description = "Accès refusé - vous devez être membre de la colocation"),
+                    @ApiResponse(responseCode = "404", description = "Stock ou colocation non trouvé(e)")
+            }
+    )
+    public ResponseEntity<StockResDto> getStockById(
+            @Parameter(description = "ID de la colocation") @PathVariable Long colocationId,
+            @Parameter(description = "ID du stock") @PathVariable Long stockId) throws
+                                                                                TechnicalException {
+        StockResDto result = stockService.getStockById(colocationId, stockId);
+        return ResponseEntity.ok(result);
+    }
+
+    @DeleteMapping("/{stockId}")
+    @Operation(summary = "Supprimer un stock", description = "Supprime un stock (seul le gestionnaire peut supprimer)")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "204", description = "Stock supprimé avec succès"),
+                    @ApiResponse(responseCode = "401", description = "Utilisateur non authentifié"),
+                    @ApiResponse(responseCode = "403", description = "Accès refusé - seul le gestionnaire peut supprimer"),
+                    @ApiResponse(responseCode = "404", description = "Stock ou colocation non trouvé(e)")
+            }
+    )
+    public ResponseEntity<Void> deleteStock(
+            @Parameter(description = "ID de la colocation") @PathVariable Long colocationId,
+            @Parameter(description = "ID du stock") @PathVariable Long stockId) throws
+                                                                                TechnicalException {
+        stockService.deleteStock(colocationId, stockId);
+        return ResponseEntity.noContent()
+                             .build();
+    }
+
+    // Stock Items endpoints
+
+    @PostMapping("/{stockId}/items")
+    @Operation(summary = "Ajouter un item au stock", description = "Ajoute un nouvel item à un stock existant")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "201", description = "Item ajouté avec succès"),
+                    @ApiResponse(responseCode = "400", description = "Données invalides"),
+                    @ApiResponse(responseCode = "401", description = "Utilisateur non authentifié"),
+                    @ApiResponse(responseCode = "403", description = "Accès refusé - vous devez être membre de la colocation"),
+                    @ApiResponse(responseCode = "404", description = "Stock ou colocation non trouvé(e)"),
+                    @ApiResponse(responseCode = "409", description = "Un item avec ce nom existe déjà dans ce stock")
+            }
+    )
+    public ResponseEntity<StockItemResDto> addItemToStock(
+            @Parameter(description = "ID de la colocation") @PathVariable Long colocationId,
+            @Parameter(description = "ID du stock") @PathVariable Long stockId,
+            @Valid @RequestBody StockItemReqDto dto) throws
+                                                     TechnicalException {
+        StockItemResDto result = stockService.addItemToStock(colocationId, stockId, dto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                             .body(result);
+    }
+
+    @PutMapping("/{stockId}/items/{itemId}")
+    @Operation(summary = "Modifier un item", description = "Modifie un item existant dans le stock")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Item modifié avec succès"),
+                    @ApiResponse(responseCode = "400", description = "Données invalides"),
+                    @ApiResponse(responseCode = "401", description = "Utilisateur non authentifié"),
+                    @ApiResponse(responseCode = "403", description = "Accès refusé - vous devez être membre de la colocation"),
+                    @ApiResponse(responseCode = "404", description = "Item, stock ou colocation non trouvé(e)")
+            }
+    )
+    public ResponseEntity<StockItemResDto> updateStockItem(
+            @Parameter(description = "ID de la colocation") @PathVariable Long colocationId,
+            @Parameter(description = "ID du stock") @PathVariable Long stockId,
+            @Parameter(description = "ID de l'item") @PathVariable Long itemId,
+            @Valid @RequestBody StockItemReqDto dto) throws
+                                                     TechnicalException {
+        StockItemResDto result = stockService.updateStockItem(colocationId, stockId, itemId, dto);
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{stockId}/items")
+    @Operation(summary = "Obtenir tous les items", description = "Récupère tous les items d'un stock")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Liste des items"),
+                    @ApiResponse(responseCode = "401", description = "Utilisateur non authentifié"),
+                    @ApiResponse(responseCode = "403", description = "Accès refusé - vous devez être membre de la colocation"),
+                    @ApiResponse(responseCode = "404", description = "Stock ou colocation non trouvé(e)")
+            }
+    )
+    public ResponseEntity<List<StockItemResDto>> getStockItems(
+            @Parameter(description = "ID de la colocation") @PathVariable Long colocationId,
+            @Parameter(description = "ID du stock") @PathVariable Long stockId) throws
+                                                                                TechnicalException {
+        List<StockItemResDto> result = stockService.getStockItems(colocationId, stockId);
+        return ResponseEntity.ok(result);
+    }
+
+    @DeleteMapping("/{stockId}/items/{itemId}")
+    @Operation(summary = "Supprimer un item", description = "Supprime un item du stock")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "204", description = "Item supprimé avec succès"),
+                    @ApiResponse(responseCode = "401", description = "Utilisateur non authentifié"),
+                    @ApiResponse(responseCode = "403", description = "Accès refusé - vous devez être membre de la colocation"),
+                    @ApiResponse(responseCode = "404", description = "Item, stock ou colocation non trouvé(e)")
+            }
+    )
+    public ResponseEntity<Void> deleteStockItem(
+            @Parameter(description = "ID de la colocation") @PathVariable Long colocationId,
+            @Parameter(description = "ID du stock") @PathVariable Long stockId,
+            @Parameter(description = "ID de l'item") @PathVariable Long itemId) throws
+                                                                                TechnicalException {
+        stockService.deleteStockItem(colocationId, stockId, itemId);
+        return ResponseEntity.noContent()
+                             .build();
+    }
+}

--- a/co-habit-project/co-habit-rest/src/test/java/fr/esgi/rest/interne/StockRestTest.java
+++ b/co-habit-project/co-habit-rest/src/test/java/fr/esgi/rest/interne/StockRestTest.java
@@ -1,0 +1,273 @@
+package fr.esgi.rest.interne;
+
+import fr.esgi.domain.dto.space.StockItemReqDto;
+import fr.esgi.domain.dto.space.StockItemResDto;
+import fr.esgi.domain.dto.space.StockReqDto;
+import fr.esgi.domain.dto.space.StockResDto;
+import fr.esgi.domain.dto.user.UserProfileResDto;
+import fr.esgi.domain.exception.TechnicalException;
+import fr.esgi.service.space.StockService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StockRestTest {
+
+    @Mock
+    private StockService stockService;
+
+    @InjectMocks
+    private StockRest stockRest;
+
+    private Long            colocationId;
+    private Long            stockId;
+    private Long            itemId;
+    private StockReqDto     testStockRequestDto;
+    private StockResDto     testStockResponseDto;
+    private StockItemReqDto testItemRequestDto;
+    private StockItemResDto testItemResponseDto;
+
+    @BeforeEach
+    void setUp() {
+        colocationId         = 1L;
+        stockId              = 2L;
+        itemId               = 3L;
+        testStockRequestDto  = createTestStockRequestDto();
+        testStockResponseDto = createTestStockResponseDto();
+        testItemRequestDto   = createTestItemRequestDto();
+        testItemResponseDto  = createTestItemResponseDto();
+    }
+
+    // Stock endpoints tests
+
+    @Test
+    void createStock_ShouldReturnCreatedStock() throws
+                                                TechnicalException {
+        // Given
+        when(stockService.createStock(eq(colocationId), any(StockReqDto.class)))
+                .thenReturn(testStockResponseDto);
+
+        // When
+        ResponseEntity<StockResDto> result = stockRest.createStock(colocationId, testStockRequestDto);
+
+        // Then
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(result.getBody()).isEqualTo(testStockResponseDto);
+        verify(stockService).createStock(colocationId, testStockRequestDto);
+    }
+
+    @Test
+    void updateStock_ShouldReturnUpdatedStock() throws
+                                                TechnicalException {
+        // Given
+        when(stockService.updateStock(eq(colocationId), eq(stockId), any(StockReqDto.class)))
+                .thenReturn(testStockResponseDto);
+
+        // When
+        ResponseEntity<StockResDto> result = stockRest.updateStock(colocationId, stockId, testStockRequestDto);
+
+        // Then
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody()).isEqualTo(testStockResponseDto);
+        verify(stockService).updateStock(colocationId, stockId, testStockRequestDto);
+    }
+
+    @Test
+    void getStocksByColocation_ShouldReturnStockList() throws
+                                                       TechnicalException {
+        // Given
+        List<StockResDto> expectedStocks = List.of(testStockResponseDto);
+        when(stockService.getStocksByColocation(colocationId)).thenReturn(expectedStocks);
+
+        // When
+        ResponseEntity<List<StockResDto>> result = stockRest.getStocksByColocation(colocationId);
+
+        // Then
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody()).isEqualTo(expectedStocks);
+        assertThat(result.getBody()).hasSize(1);
+        verify(stockService).getStocksByColocation(colocationId);
+    }
+
+    @Test
+    void getStockById_ShouldReturnStock() throws
+                                          TechnicalException {
+        // Given
+        when(stockService.getStockById(colocationId, stockId)).thenReturn(testStockResponseDto);
+
+        // When
+        ResponseEntity<StockResDto> result = stockRest.getStockById(colocationId, stockId);
+
+        // Then
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody()).isEqualTo(testStockResponseDto);
+        verify(stockService).getStockById(colocationId, stockId);
+    }
+
+    @Test
+    void deleteStock_ShouldCallServiceAndReturnNoContent() throws
+                                                           TechnicalException {
+        // When
+        ResponseEntity<Void> result = stockRest.deleteStock(colocationId, stockId);
+
+        // Then
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(result.getBody()).isNull();
+        verify(stockService).deleteStock(colocationId, stockId);
+    }
+
+    // Stock items endpoints tests
+
+    @Test
+    void addItemToStock_ShouldReturnCreatedItem() throws
+                                                  TechnicalException {
+        // Given
+        when(stockService.addItemToStock(eq(colocationId), eq(stockId), any(StockItemReqDto.class)))
+                .thenReturn(testItemResponseDto);
+
+        // When
+        ResponseEntity<StockItemResDto> result = stockRest.addItemToStock(colocationId, stockId, testItemRequestDto);
+
+        // Then
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(result.getBody()).isEqualTo(testItemResponseDto);
+        verify(stockService).addItemToStock(colocationId, stockId, testItemRequestDto);
+    }
+
+    @Test
+    void updateStockItem_ShouldReturnUpdatedItem() throws
+                                                   TechnicalException {
+        // Given
+        when(stockService.updateStockItem(eq(colocationId), eq(stockId), eq(itemId), any(StockItemReqDto.class)))
+                .thenReturn(testItemResponseDto);
+
+        // When
+        ResponseEntity<StockItemResDto> result = stockRest.updateStockItem(colocationId, stockId, itemId, testItemRequestDto);
+
+        // Then
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody()).isEqualTo(testItemResponseDto);
+        verify(stockService).updateStockItem(colocationId, stockId, itemId, testItemRequestDto);
+    }
+
+    @Test
+    void getStockItems_ShouldReturnItemList() throws
+                                              TechnicalException {
+        // Given
+        List<StockItemResDto> expectedItems = List.of(testItemResponseDto);
+        when(stockService.getStockItems(colocationId, stockId)).thenReturn(expectedItems);
+
+        // When
+        ResponseEntity<List<StockItemResDto>> result = stockRest.getStockItems(colocationId, stockId);
+
+        // Then
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody()).isEqualTo(expectedItems);
+        assertThat(result.getBody()).hasSize(1);
+        verify(stockService).getStockItems(colocationId, stockId);
+    }
+
+    @Test
+    void deleteStockItem_ShouldCallServiceAndReturnNoContent() throws
+                                                               TechnicalException {
+        // When
+        ResponseEntity<Void> result = stockRest.deleteStockItem(colocationId, stockId, itemId);
+
+        // Then
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(result.getBody()).isNull();
+        verify(stockService).deleteStockItem(colocationId, stockId, itemId);
+    }
+
+    @Test
+    void addItemToStock_ShouldThrowExceptionWhenCapacityExceeded() throws
+                                                                   TechnicalException {
+        // Given
+        when(stockService.addItemToStock(eq(colocationId), eq(stockId), any(StockItemReqDto.class)))
+                .thenThrow(new TechnicalException(400, "La quantité totale (15) dépasserait la capacité maximale du stock (10)"));
+
+        // When & Then
+        TechnicalException exception = assertThrows(TechnicalException.class,
+                                                    () -> stockRest.addItemToStock(colocationId, stockId, testItemRequestDto));
+
+        assertEquals(400, exception.getCode());
+        assertTrue(exception.getMessage()
+                            .contains("dépasserait la capacité maximale du stock"));
+    }
+
+    @Test
+    void updateStockItem_ShouldThrowExceptionWhenCapacityExceeded() throws
+                                                                    TechnicalException {
+        // Given
+        when(stockService.updateStockItem(eq(colocationId), eq(stockId), eq(itemId), any(StockItemReqDto.class)))
+                .thenThrow(new TechnicalException(400, "La quantité totale (20) dépasserait la capacité maximale du stock (15)"));
+
+        // When & Then
+        TechnicalException exception = assertThrows(TechnicalException.class,
+                                                    () -> stockRest.updateStockItem(colocationId, stockId, itemId, testItemRequestDto));
+
+        assertEquals(400, exception.getCode());
+        assertTrue(exception.getMessage()
+                            .contains("dépasserait la capacité maximale du stock"));
+    }
+
+    // Test data builders
+    private StockReqDto createTestStockRequestDto() {
+        return StockReqDto.builder()
+                          .title("Test Stock")
+                          .imageAsset("test-stock.png")
+                          .color("#FF5733")
+                          .maxCapacity(50)
+                          .build();
+    }
+
+    private StockResDto createTestStockResponseDto() {
+        return StockResDto.builder()
+                          .id(stockId)
+                          .title("Test Stock")
+                          .imageAsset("test-stock.png")
+                          .color("#FF5733")
+                          .maxCapacity(50)
+                          .itemCount(5)
+                          .build();
+    }
+
+    private StockItemReqDto createTestItemRequestDto() {
+        return StockItemReqDto.builder()
+                              .name("Test Item")
+                              .quantity(10)
+                              .build();
+    }
+
+    private StockItemResDto createTestItemResponseDto() {
+        UserProfileResDto addedByUser = UserProfileResDto.builder()
+                                                         .id(1L)
+                                                         .firstName("John")
+                                                         .lastName("Doe")
+                                                         .fullName("John Doe")
+                                                         .email("john.doe@example.com")
+                                                         .build();
+
+        return StockItemResDto.builder()
+                              .id(itemId)
+                              .name("Test Item")
+                              .quantity(10)
+                              .addedBy(addedByUser)
+                              .build();
+    }
+}

--- a/co-habit-project/co-habit-service/src/main/java/fr/esgi/service/space/StockService.java
+++ b/co-habit-project/co-habit-service/src/main/java/fr/esgi/service/space/StockService.java
@@ -1,0 +1,331 @@
+package fr.esgi.service.space;
+
+import fr.esgi.domain.dto.space.StockItemReqDto;
+import fr.esgi.domain.dto.space.StockItemResDto;
+import fr.esgi.domain.dto.space.StockReqDto;
+import fr.esgi.domain.dto.space.StockResDto;
+import fr.esgi.domain.exception.TechnicalException;
+import fr.esgi.persistence.entity.space.Colocation;
+import fr.esgi.persistence.entity.space.StockEntity;
+import fr.esgi.persistence.entity.space.StockItemEntity;
+import fr.esgi.persistence.entity.user.User;
+import fr.esgi.persistence.repository.space.ColocationRepository;
+import fr.esgi.persistence.repository.space.StockItemRepository;
+import fr.esgi.persistence.repository.space.StockRepository;
+import fr.esgi.persistence.repository.user.UserRepository;
+import fr.esgi.service.AbstractService;
+import fr.esgi.service.space.mapper.StockMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StockService extends AbstractService {
+
+    private final StockRepository      stockRepository;
+    private final StockItemRepository  stockItemRepository;
+    private final ColocationRepository colocationRepository;
+    private final UserRepository       userRepository;
+    private final StockMapper          stockMapper;
+
+    /**
+     * Creates a new stock for a colocation
+     */
+    public StockResDto createStock(Long colocationId, StockReqDto dto) throws
+                                                                       TechnicalException {
+        String userSub = getUserSub();
+
+        User user = userRepository.findByKeyCloakSub(userSub)
+                                  .orElseThrow(() -> new TechnicalException(404, "Utilisateur n'est pas trouvé"));
+
+        Colocation colocation = colocationRepository.findById(colocationId)
+                                                    .orElseThrow(() -> new TechnicalException(404, "Colocation non trouvée"));
+
+        if (!colocation.isRoommate(user) && !colocation.isManager(user)) {
+            throw new TechnicalException(403, "Vous devez être membre de cette colocation");
+        }
+
+        if (stockRepository.existsByTitleAndColocationId(dto.getTitle(), colocationId)) {
+            throw new TechnicalException(409, "Un stock avec ce titre existe déjà dans cette colocation");
+        }
+
+        StockEntity stock = stockMapper.mapDtoToStock(dto);
+        stock.setColocation(colocation);
+
+        StockEntity savedStock = stockRepository.save(stock);
+        return stockMapper.mapStockToResDto(savedStock);
+    }
+
+    /**
+     * Updates an existing stock
+     */
+    public StockResDto updateStock(Long colocationId, Long stockId, StockReqDto dto) throws
+                                                                                     TechnicalException {
+        String userSub = getUserSub();
+
+        User user = userRepository.findByKeyCloakSub(userSub)
+                                  .orElseThrow(() -> new TechnicalException(404, "Utilisateur n'est pas trouvé"));
+
+        Colocation colocation = colocationRepository.findById(colocationId)
+                                                    .orElseThrow(() -> new TechnicalException(404, "Colocation non trouvée"));
+
+        if (!colocation.isRoommate(user) && !colocation.isManager(user)) {
+            throw new TechnicalException(403, "Vous devez être membre de cette colocation");
+        }
+
+        StockEntity stock = stockRepository.findByIdAndColocationId(stockId, colocationId)
+                                           .orElseThrow(() -> new TechnicalException(404, "Stock non trouvé"));
+
+        stockMapper.updateStockFromDto(dto, stock);
+        StockEntity updatedStock = stockRepository.save(stock);
+        return stockMapper.mapStockToResDto(updatedStock);
+    }
+
+    /**
+     * Gets all stocks for a colocation
+     */
+    @Transactional(readOnly = true)
+    public List<StockResDto> getStocksByColocation(Long colocationId) throws
+                                                                      TechnicalException {
+        String userSub = getUserSub();
+
+        User user = userRepository.findByKeyCloakSub(userSub)
+                                  .orElseThrow(() -> new TechnicalException(404, "Utilisateur n'est pas trouvé"));
+
+        Colocation colocation = colocationRepository.findById(colocationId)
+                                                    .orElseThrow(() -> new TechnicalException(404, "Colocation non trouvée"));
+
+        if (!colocation.isRoommate(user) && !colocation.isManager(user)) {
+            throw new TechnicalException(403, "Vous devez être membre de cette colocation");
+        }
+
+        List<StockEntity> stocks = stockRepository.findByColocationId(colocationId);
+        return stockMapper.mapStocksToResDtos(stocks);
+    }
+
+    /**
+     * Gets a specific stock by ID
+     */
+    @Transactional(readOnly = true)
+    public StockResDto getStockById(Long colocationId, Long stockId) throws
+                                                                     TechnicalException {
+        String userSub = getUserSub();
+
+        User user = userRepository.findByKeyCloakSub(userSub)
+                                  .orElseThrow(() -> new TechnicalException(404, "Utilisateur n'est pas trouvé"));
+
+        Colocation colocation = colocationRepository.findById(colocationId)
+                                                    .orElseThrow(() -> new TechnicalException(404, "Colocation non trouvée"));
+
+        if (!colocation.isRoommate(user) && !colocation.isManager(user)) {
+            throw new TechnicalException(403, "Vous devez être membre de cette colocation");
+        }
+
+        StockEntity stock = stockRepository.findByIdAndColocationId(stockId, colocationId)
+                                           .orElseThrow(() -> new TechnicalException(404, "Stock non trouvé"));
+
+        return stockMapper.mapStockToResDto(stock);
+    }
+
+    /**
+     * Deletes a stock
+     */
+    public void deleteStock(Long colocationId, Long stockId) throws
+                                                             TechnicalException {
+        String userSub = getUserSub();
+
+        User user = userRepository.findByKeyCloakSub(userSub)
+                                  .orElseThrow(() -> new TechnicalException(404, "Utilisateur n'est pas trouvé"));
+
+        Colocation colocation = colocationRepository.findById(colocationId)
+                                                    .orElseThrow(() -> new TechnicalException(404, "Colocation non trouvée"));
+
+        if (!colocation.isManager(user)) {
+            throw new TechnicalException(403, "Seul le gestionnaire peut supprimer un stock");
+        }
+
+        StockEntity stock = stockRepository.findByIdAndColocationId(stockId, colocationId)
+                                           .orElseThrow(() -> new TechnicalException(404, "Stock non trouvé"));
+
+        stockRepository.delete(stock);
+    }
+
+    /**
+     * Deletes a stock by ID with all its items
+     */
+    public void deleteStockById(Long stockId) throws
+                                              TechnicalException {
+        String userSub = getUserSub();
+
+        User user = userRepository.findByKeyCloakSub(userSub)
+                                  .orElseThrow(() -> new TechnicalException(404, "Utilisateur n'est pas trouvé"));
+
+        StockEntity stock = stockRepository.findById(stockId)
+                                           .orElseThrow(() -> new TechnicalException(404, "Stock non trouvé"));
+
+        Colocation colocation = stock.getColocation();
+
+        if (!colocation.isManager(user)) {
+            throw new TechnicalException(403, "Seul le gestionnaire peut supprimer un stock");
+        }
+
+        // Delete all items first (if needed for audit or custom logic)
+        List<StockItemEntity> items = stockItemRepository.findByStockId(stockId);
+        stockItemRepository.deleteAll(items);
+
+        // Delete the stock (cascade will also delete items)
+        stockRepository.delete(stock);
+    }
+
+    /**
+     * Calculates the current total quantity of items in a stock
+     */
+    private int getCurrentTotalQuantity(Long stockId) {
+        List<StockItemEntity> items = stockItemRepository.findByStockId(stockId);
+        return items.stream()
+                   .mapToInt(item -> item.getQuantity() != null ? item.getQuantity() : 0)
+                   .sum();
+    }
+
+    /**
+     * Validates if adding the given quantity would exceed the stock's max capacity
+     */
+    private void validateCapacity(StockEntity stock, int additionalQuantity, Long excludeItemId) throws TechnicalException {
+        if (stock.getMaxCapacity() == null) {
+            return; // No capacity limit
+        }
+
+        int currentTotal = getCurrentTotalQuantity(stock.getId());
+        
+        // If we're updating an existing item, subtract its current quantity
+        if (excludeItemId != null) {
+            StockItemEntity existingItem = stockItemRepository.findById(excludeItemId).orElse(null);
+            if (existingItem != null && existingItem.getQuantity() != null) {
+                currentTotal -= existingItem.getQuantity();
+            }
+        }
+
+        int newTotal = currentTotal + additionalQuantity;
+        
+        if (newTotal > stock.getMaxCapacity()) {
+            throw new TechnicalException(400, 
+                String.format("La quantité totale (%d) dépasserait la capacité maximale du stock (%d)", 
+                             newTotal, stock.getMaxCapacity()));
+        }
+    }
+
+    /**
+     * Adds an item to a stock
+     */
+    public StockItemResDto addItemToStock(Long colocationId, Long stockId, StockItemReqDto dto) throws
+                                                                                                TechnicalException {
+        String userSub = getUserSub();
+
+        User user = userRepository.findByKeyCloakSub(userSub)
+                                  .orElseThrow(() -> new TechnicalException(404, "Utilisateur n'est pas trouvé"));
+
+        Colocation colocation = colocationRepository.findById(colocationId)
+                                                    .orElseThrow(() -> new TechnicalException(404, "Colocation non trouvée"));
+
+        if (!colocation.isRoommate(user) && !colocation.isManager(user)) {
+            throw new TechnicalException(403, "Vous devez être membre de cette colocation");
+        }
+
+        StockEntity stock = stockRepository.findByIdAndColocationId(stockId, colocationId)
+                                           .orElseThrow(() -> new TechnicalException(404, "Stock non trouvé"));
+
+        // Validate capacity before adding
+        int quantityToAdd = dto.getQuantity() != null ? dto.getQuantity() : 0;
+        validateCapacity(stock, quantityToAdd, null);
+
+        StockItemEntity stockItem = stockMapper.mapDtoToStockItem(dto);
+        stockItem.setStock(stock);
+        stockItem.setAddedBy(user);
+
+        StockItemEntity savedItem = stockItemRepository.save(stockItem);
+        return stockMapper.mapStockItemToResDto(savedItem);
+    }
+
+    /**
+     * Updates a stock item
+     */
+    public StockItemResDto updateStockItem(Long colocationId, Long stockId, Long itemId, StockItemReqDto dto) throws
+                                                                                                              TechnicalException {
+        String userSub = getUserSub();
+
+        User user = userRepository.findByKeyCloakSub(userSub)
+                                  .orElseThrow(() -> new TechnicalException(404, "Utilisateur n'est pas trouvé"));
+
+        Colocation colocation = colocationRepository.findById(colocationId)
+                                                    .orElseThrow(() -> new TechnicalException(404, "Colocation non trouvée"));
+
+        if (!colocation.isRoommate(user) && !colocation.isManager(user)) {
+            throw new TechnicalException(403, "Vous devez être membre de cette colocation");
+        }
+
+        StockItemEntity stockItem = stockItemRepository.findByIdAndStockId(itemId, stockId)
+                                                       .orElseThrow(() -> new TechnicalException(404, "Item non trouvé"));
+
+        StockEntity stock = stockItem.getStock();
+        
+        // Validate capacity before updating
+        int newQuantity = dto.getQuantity() != null ? dto.getQuantity() : 0;
+        validateCapacity(stock, newQuantity, itemId);
+
+        stockMapper.updateStockItemFromDto(dto, stockItem);
+        StockItemEntity updatedItem = stockItemRepository.save(stockItem);
+        return stockMapper.mapStockItemToResDto(updatedItem);
+    }
+
+    /**
+     * Gets all items for a stock
+     */
+    @Transactional(readOnly = true)
+    public List<StockItemResDto> getStockItems(Long colocationId, Long stockId) throws
+                                                                                TechnicalException {
+        String userSub = getUserSub();
+
+        User user = userRepository.findByKeyCloakSub(userSub)
+                                  .orElseThrow(() -> new TechnicalException(404, "Utilisateur n'est pas trouvé"));
+
+        Colocation colocation = colocationRepository.findById(colocationId)
+                                                    .orElseThrow(() -> new TechnicalException(404, "Colocation non trouvée"));
+
+        if (!colocation.isRoommate(user) && !colocation.isManager(user)) {
+            throw new TechnicalException(403, "Vous devez être membre de cette colocation");
+        }
+
+        stockRepository.findByIdAndColocationId(stockId, colocationId)
+                       .orElseThrow(() -> new TechnicalException(404, "Stock non trouvé"));
+
+        List<StockItemEntity> items = stockItemRepository.findByStockId(stockId);
+        return stockMapper.mapStockItemsToResDtos(items);
+    }
+
+    /**
+     * Deletes a stock item
+     */
+    public void deleteStockItem(Long colocationId, Long stockId, Long itemId) throws
+                                                                              TechnicalException {
+        String userSub = getUserSub();
+
+        User user = userRepository.findByKeyCloakSub(userSub)
+                                  .orElseThrow(() -> new TechnicalException(404, "Utilisateur n'est pas trouvé"));
+
+        Colocation colocation = colocationRepository.findById(colocationId)
+                                                    .orElseThrow(() -> new TechnicalException(404, "Colocation non trouvée"));
+
+        if (!colocation.isRoommate(user) && !colocation.isManager(user)) {
+            throw new TechnicalException(403, "Vous devez être membre de cette colocation");
+        }
+
+        StockItemEntity stockItem = stockItemRepository.findByIdAndStockId(itemId, stockId)
+                                                       .orElseThrow(() -> new TechnicalException(404, "Item non trouvé"));
+
+        stockItemRepository.delete(stockItem);
+    }
+}

--- a/co-habit-project/co-habit-service/src/main/java/fr/esgi/service/space/mapper/StockMapper.java
+++ b/co-habit-project/co-habit-service/src/main/java/fr/esgi/service/space/mapper/StockMapper.java
@@ -1,0 +1,63 @@
+package fr.esgi.service.space.mapper;
+
+import fr.esgi.domain.dto.space.StockItemReqDto;
+import fr.esgi.domain.dto.space.StockItemResDto;
+import fr.esgi.domain.dto.space.StockReqDto;
+import fr.esgi.domain.dto.space.StockResDto;
+import fr.esgi.persistence.entity.space.StockEntity;
+import fr.esgi.persistence.entity.space.StockItemEntity;
+import fr.esgi.service.registration.mapper.UserMapper;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Named;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring", uses = {UserMapper.class})
+public interface StockMapper {
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "colocation", ignore = true)
+    @Mapping(target = "items", ignore = true)
+    StockEntity mapDtoToStock(StockReqDto dto);
+
+    @Mapping(target = "itemCount", source = ".", qualifiedByName = "calculateTotalQuantity")
+    StockResDto mapStockToResDto(StockEntity stock);
+
+    List<StockResDto> mapStocksToResDtos(List<StockEntity> stocks);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "colocation", ignore = true)
+    @Mapping(target = "items", ignore = true)
+    void updateStockFromDto(StockReqDto dto, @MappingTarget StockEntity stock);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "stock", ignore = true)
+    @Mapping(target = "addedBy", ignore = true)
+    @Mapping(target = "addedAt", ignore = true)
+    StockItemEntity mapDtoToStockItem(StockItemReqDto dto);
+
+    @Mapping(target = "addedBy", source = "addedBy")
+    StockItemResDto mapStockItemToResDto(StockItemEntity stockItem);
+
+    List<StockItemResDto> mapStockItemsToResDtos(List<StockItemEntity> stockItems);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "stock", ignore = true)
+    @Mapping(target = "addedBy", ignore = true)
+    @Mapping(target = "addedAt", ignore = true)
+    void updateStockItemFromDto(StockItemReqDto dto, @MappingTarget StockItemEntity stockItem);
+
+    @Named("calculateTotalQuantity")
+    default int calculateTotalQuantity(StockEntity stock) {
+        if (stock.getItems() == null) {
+            return 0;
+        }
+
+        return stock.getItems()
+                    .stream()
+                    .mapToInt(item -> item.getQuantity() != null ? item.getQuantity() : 0)
+                    .sum();
+    }
+}

--- a/co-habit-project/co-habit-service/src/test/java/fr/esgi/service/space/StockServiceTest.java
+++ b/co-habit-project/co-habit-service/src/test/java/fr/esgi/service/space/StockServiceTest.java
@@ -1,0 +1,847 @@
+package fr.esgi.service.space;
+
+import fr.esgi.domain.dto.space.StockItemReqDto;
+import fr.esgi.domain.dto.space.StockItemResDto;
+import fr.esgi.domain.dto.space.StockReqDto;
+import fr.esgi.domain.dto.space.StockResDto;
+import fr.esgi.domain.exception.TechnicalException;
+import fr.esgi.persistence.entity.space.Colocation;
+import fr.esgi.persistence.entity.space.StockEntity;
+import fr.esgi.persistence.entity.space.StockItemEntity;
+import fr.esgi.persistence.entity.user.User;
+import fr.esgi.persistence.repository.space.ColocationRepository;
+import fr.esgi.persistence.repository.space.StockItemRepository;
+import fr.esgi.persistence.repository.space.StockRepository;
+import fr.esgi.persistence.repository.user.UserRepository;
+import fr.esgi.service.AbstractTest;
+import fr.esgi.service.registration.mapper.UserMapper;
+import fr.esgi.service.space.mapper.StockMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mapstruct.factory.Mappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.reactive.ReactiveWebServerFactoryAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@Import(StockServiceTest.TestConfig.class)
+@TestPropertySource(
+        properties = {
+                "spring.datasource.url=jdbc:h2:mem:testdb",
+                "spring.jpa.hibernate.ddl-auto=create-drop",
+                "spring.datasource.driver-class-name=org.h2.Driver",
+                "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect"
+        }
+)
+@EnableJpaRepositories(basePackages = "fr.esgi.persistence.repository")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class StockServiceTest extends AbstractTest {
+
+    @TestConfiguration
+    @EnableAutoConfiguration(
+            exclude = {
+                    ServletWebServerFactoryAutoConfiguration.class,
+                    ReactiveWebServerFactoryAutoConfiguration.class
+            }
+    )
+    static class TestConfig {
+
+        @Bean
+        public StockMapper stockMapper() {
+            return Mappers.getMapper(StockMapper.class);
+        }
+
+        @Bean
+        public UserMapper userMapper() {
+            return Mappers.getMapper(UserMapper.class);
+        }
+
+        @Bean
+        public StockService stockService(
+                StockRepository stockRepository,
+                StockItemRepository stockItemRepository,
+                ColocationRepository colocationRepository,
+                UserRepository userRepository,
+                StockMapper stockMapper,
+                UserMapper userMapper) {
+            return new StockService(stockRepository, stockItemRepository, colocationRepository, userRepository, stockMapper);
+        }
+    }
+
+    @Autowired
+    private StockRepository stockRepository;
+
+    @Autowired
+    private StockItemRepository stockItemRepository;
+
+    @Autowired
+    private ColocationRepository colocationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private StockService stockService;
+
+    private User       managerUser;
+    private User       roommateUser;
+    private User       otherUser;
+    private Colocation colocation;
+
+    @BeforeEach
+    public void initData() {
+        // Setup users
+        managerUser = new User();
+        managerUser.setEmail("manager@example.com");
+        managerUser.setFirstName("John");
+        managerUser.setLastName("Manager");
+        managerUser.setKeyCloakSub(TEST_USER_ID);
+        managerUser.setBirthDate(LocalDate.of(1990, 1, 1));
+        managerUser = userRepository.save(managerUser);
+
+        roommateUser = new User();
+        roommateUser.setEmail("roommate@example.com");
+        roommateUser.setFirstName("Jane");
+        roommateUser.setLastName("Roommate");
+        roommateUser.setKeyCloakSub("roommate-sub");
+        roommateUser.setBirthDate(LocalDate.of(1992, 1, 1));
+        roommateUser = userRepository.save(roommateUser);
+
+        otherUser = new User();
+        otherUser.setEmail("other@example.com");
+        otherUser.setFirstName("Bob");
+        otherUser.setLastName("Other");
+        otherUser.setKeyCloakSub("other-sub");
+        otherUser.setBirthDate(LocalDate.of(1988, 1, 1));
+        otherUser = userRepository.save(otherUser);
+
+        // Setup colocation
+        colocation = new Colocation("Test Coloc", "Test Address", managerUser);
+        colocation.addRoommate(roommateUser);
+        colocation = colocationRepository.save(colocation);
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        stockItemRepository.deleteAll();
+        stockRepository.deleteAll();
+        colocationRepository.deleteAll();
+        userRepository.deleteAll();
+        this.cleanupSecurityContext();
+    }
+
+    @Test
+    public void testCreateStock_Success() throws
+                                          TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockReqDto dto = new StockReqDto();
+        dto.setTitle("Frigo");
+        dto.setColor("#00FF00");
+        dto.setImageAsset("fridge.png");
+        dto.setMaxCapacity(50);
+
+        // When
+        StockResDto result = stockService.createStock(colocation.getId(), dto);
+
+        // Then
+        assertNotNull(result);
+        assertEquals("Frigo", result.getTitle());
+        assertEquals("#00FF00", result.getColor());
+        assertEquals("fridge.png", result.getImageAsset());
+        assertEquals(50, result.getMaxCapacity());
+        assertNotNull(result.getId());
+
+        // Verify in database
+        Optional<StockEntity> savedStock = stockRepository.findById(result.getId());
+        assertTrue(savedStock.isPresent());
+        assertEquals(colocation,
+                     savedStock.get()
+                               .getColocation());
+    }
+
+    @Test
+    public void testCreateStock_NotMember() {
+        // Given
+        this.initSecurityContextPlaceHolderWithSub("other-sub");
+
+        StockReqDto dto = new StockReqDto();
+        dto.setTitle("Test Stock");
+
+        // When & Then
+        TechnicalException exception = assertThrows(TechnicalException.class,
+                                                    () -> stockService.createStock(colocation.getId(), dto));
+
+        assertEquals(403, exception.getCode());
+        assertEquals("Vous devez être membre de cette colocation", exception.getMessage());
+    }
+
+    @Test
+    public void testCreateStock_DuplicateTitle() throws
+                                                 TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        // Create first stock
+        StockEntity existingStock = new StockEntity("Frigo", colocation);
+        stockRepository.save(existingStock);
+
+        StockReqDto dto = new StockReqDto();
+        dto.setTitle("Frigo");
+
+        // When & Then
+        TechnicalException exception = assertThrows(TechnicalException.class,
+                                                    () -> stockService.createStock(colocation.getId(), dto));
+
+        assertEquals(409, exception.getCode());
+        assertEquals("Un stock avec ce titre existe déjà dans cette colocation", exception.getMessage());
+    }
+
+    @Test
+    public void testUpdateStock_Success() throws
+                                          TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockEntity stock = new StockEntity("Original Title", colocation);
+        stock = stockRepository.save(stock);
+
+        StockReqDto updateDto = new StockReqDto();
+        updateDto.setTitle("Updated Title");
+        updateDto.setColor("#FF0000");
+        updateDto.setMaxCapacity(100);
+
+        // When
+        StockResDto result = stockService.updateStock(colocation.getId(), stock.getId(), updateDto);
+
+        // Then
+        assertNotNull(result);
+        assertEquals("Updated Title", result.getTitle());
+        assertEquals("#FF0000", result.getColor());
+        assertEquals(100, result.getMaxCapacity());
+    }
+
+    @Test
+    public void testGetStocksByColocation_Success() throws
+                                                    TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockEntity stock1 = new StockEntity("Frigo", colocation);
+        StockEntity stock2 = new StockEntity("Garde-manger", colocation);
+        stockRepository.saveAll(List.of(stock1, stock2));
+
+        // When
+        List<StockResDto> result = stockService.getStocksByColocation(colocation.getId());
+
+        // Then
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertTrue(result.stream()
+                         .anyMatch(s -> s.getTitle()
+                                         .equals("Frigo")));
+        assertTrue(result.stream()
+                         .anyMatch(s -> s.getTitle()
+                                         .equals("Garde-manger")));
+    }
+
+    @Test
+    public void testDeleteStock_Success() throws
+                                          TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockEntity stock = new StockEntity("Test Stock", colocation);
+        stock = stockRepository.save(stock);
+        Long stockId = stock.getId();
+
+        // When
+        stockService.deleteStock(colocation.getId(), stockId);
+
+        // Then
+        Optional<StockEntity> deletedStock = stockRepository.findById(stockId);
+        assertFalse(deletedStock.isPresent());
+    }
+
+    @Test
+    public void testDeleteStock_NotManager() {
+        // Given
+        this.initSecurityContextPlaceHolderWithSub("roommate-sub");
+
+        StockEntity stock = new StockEntity("Test Stock", colocation);
+        stock = stockRepository.save(stock);
+
+        // When & Then
+        final StockEntity finalStock = stock;
+        TechnicalException exception = assertThrows(TechnicalException.class,
+                                                    () -> stockService.deleteStock(colocation.getId(), finalStock.getId()));
+
+        assertEquals(403, exception.getCode());
+        assertEquals("Seul le gestionnaire peut supprimer un stock", exception.getMessage());
+    }
+
+    @Test
+    public void testAddItemToStock_Success() throws
+                                             TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockEntity stock = new StockEntity("Frigo", colocation);
+        stock = stockRepository.save(stock);
+
+        StockItemReqDto dto = new StockItemReqDto();
+        dto.setName("Lait");
+        dto.setQuantity(2);
+
+        // When
+        StockItemResDto result = stockService.addItemToStock(colocation.getId(), stock.getId(), dto);
+
+        // Then
+        assertNotNull(result);
+        assertEquals("Lait", result.getName());
+        assertEquals(2, result.getQuantity());
+        assertNotNull(result.getId());
+
+        // Verify in database
+        Optional<StockItemEntity> savedItem = stockItemRepository.findById(result.getId());
+        assertTrue(savedItem.isPresent());
+        assertEquals(stock,
+                     savedItem.get()
+                              .getStock());
+        assertEquals(managerUser,
+                     savedItem.get()
+                              .getAddedBy());
+    }
+
+    @Test
+    public void testAddItemToStock_DuplicateName() throws
+                                                   TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockEntity stock = new StockEntity("Frigo", colocation);
+        stock = stockRepository.save(stock);
+
+        // Create existing item
+        StockItemEntity existingItem = new StockItemEntity("Lait", 1, managerUser);
+        existingItem.setStock(stock);
+        stockItemRepository.save(existingItem);
+
+        StockItemReqDto dto = new StockItemReqDto();
+        dto.setName("Lait");
+        dto.setQuantity(2);
+
+        // When & Then
+        final StockEntity finalStock = stock;
+        StockItemResDto   result     = stockService.addItemToStock(colocation.getId(), finalStock.getId(), dto);
+
+        assertEquals(result.getQuantity(), dto.getQuantity());
+
+        //        assertEquals("Un item avec ce nom existe déjà dans ce stock", exception.getMessage());
+    }
+
+    @Test
+    public void testUpdateStockItem_Success() throws
+                                              TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockEntity stock = new StockEntity("Frigo", colocation);
+        stock = stockRepository.save(stock);
+
+        StockItemEntity item = new StockItemEntity("Lait", 1, managerUser);
+        item.setStock(stock);
+        item = stockItemRepository.save(item);
+
+        StockItemReqDto updateDto = new StockItemReqDto();
+        updateDto.setName("Lait Bio");
+        updateDto.setQuantity(3);
+
+        // When
+        StockItemResDto result = stockService.updateStockItem(colocation.getId(), stock.getId(), item.getId(), updateDto);
+
+        // Then
+        assertNotNull(result);
+        assertEquals("Lait Bio", result.getName());
+        assertEquals(3, result.getQuantity());
+    }
+
+    @Test
+    public void testGetStockItems_Success() throws
+                                            TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockEntity stock = new StockEntity("Frigo", colocation);
+        stock = stockRepository.save(stock);
+
+        StockItemEntity item1 = new StockItemEntity("Lait", 2, managerUser);
+        item1.setStock(stock);
+        StockItemEntity item2 = new StockItemEntity("Œufs", 12, roommateUser);
+        item2.setStock(stock);
+        stockItemRepository.saveAll(List.of(item1, item2));
+
+        // When
+        List<StockItemResDto> result = stockService.getStockItems(colocation.getId(), stock.getId());
+
+        // Then
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertTrue(result.stream()
+                         .anyMatch(i -> i.getName()
+                                         .equals("Lait")));
+        assertTrue(result.stream()
+                         .anyMatch(i -> i.getName()
+                                         .equals("Œufs")));
+    }
+
+    @Test
+    public void testDeleteStockItem_Success() throws
+                                              TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockEntity stock = new StockEntity("Frigo", colocation);
+        stock = stockRepository.save(stock);
+
+        StockItemEntity item = new StockItemEntity("Lait", 2, managerUser);
+        item.setStock(stock);
+        item = stockItemRepository.save(item);
+        Long itemId = item.getId();
+
+        // When
+        stockService.deleteStockItem(colocation.getId(), stock.getId(), itemId);
+
+        // Then
+        Optional<StockItemEntity> deletedItem = stockItemRepository.findById(itemId);
+        assertFalse(deletedItem.isPresent());
+    }
+
+    @Test
+    public void testStockNotFound() {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        // When & Then
+        TechnicalException exception = assertThrows(TechnicalException.class,
+                                                    () -> stockService.getStockById(colocation.getId(), 999L));
+
+        assertEquals(404, exception.getCode());
+        assertEquals("Stock non trouvé", exception.getMessage());
+    }
+
+    @Test
+    public void testColocationNotFound() {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockReqDto dto = new StockReqDto();
+        dto.setTitle("Test");
+
+        // When & Then
+        TechnicalException exception = assertThrows(TechnicalException.class,
+                                                    () -> stockService.createStock(999L, dto));
+
+        assertEquals(404, exception.getCode());
+        assertEquals("Colocation non trouvée", exception.getMessage());
+    }
+
+    @Test
+    public void testUserNotAuthenticated() {
+        // Given - no security context
+        StockReqDto dto = new StockReqDto();
+        dto.setTitle("Test");
+
+        // When & Then
+        TechnicalException exception = assertThrows(TechnicalException.class,
+                                                    () -> stockService.createStock(colocation.getId(), dto));
+
+        assertEquals(401, exception.getCode());
+        assertEquals("User is not authenticated", exception.getMessage());
+    }
+
+    @Test
+    public void testDeleteStockById_Success() throws
+                                              TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockEntity stock = new StockEntity("Test Stock", colocation);
+        stock = stockRepository.save(stock);
+
+        // Add some items to the stock
+        StockItemEntity item1 = new StockItemEntity("Item 1", 5, managerUser);
+        item1.setStock(stock);
+        StockItemEntity item2 = new StockItemEntity("Item 2", 3, managerUser);
+        item2.setStock(stock);
+        stockItemRepository.saveAll(List.of(item1, item2));
+
+        Long stockId = stock.getId();
+
+        // When
+        stockService.deleteStockById(stockId);
+
+        // Then
+        Optional<StockEntity> deletedStock = stockRepository.findById(stockId);
+        assertFalse(deletedStock.isPresent());
+
+        // Verify all items are also deleted
+        List<StockItemEntity> remainingItems = stockItemRepository.findByStockId(stockId);
+        assertTrue(remainingItems.isEmpty());
+    }
+
+    @Test
+    public void testDeleteStockById_NotManager() {
+        // Given
+        this.initSecurityContextPlaceHolderWithSub("roommate-sub");
+
+        StockEntity stock = new StockEntity("Test Stock", colocation);
+        stock = stockRepository.save(stock);
+
+        // When & Then
+        final StockEntity finalStock = stock;
+        TechnicalException exception = assertThrows(TechnicalException.class,
+                                                    () -> stockService.deleteStockById(finalStock.getId()));
+
+        assertEquals(403, exception.getCode());
+        assertEquals("Seul le gestionnaire peut supprimer un stock", exception.getMessage());
+    }
+
+    @Test
+    public void testDeleteStockById_StockNotFound() {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        // When & Then
+        TechnicalException exception = assertThrows(TechnicalException.class,
+                                                    () -> stockService.deleteStockById(999L));
+
+        assertEquals(404, exception.getCode());
+        assertEquals("Stock non trouvé", exception.getMessage());
+    }
+
+    @Test
+    public void testDeleteStockById_WithManyItems() throws
+                                                    TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockEntity stock = new StockEntity("Stock with Many Items", colocation);
+        stock = stockRepository.save(stock);
+
+        // Add multiple items
+        List<StockItemEntity> items = new ArrayList<>();
+        for (int i = 1; i <= 10; i++) {
+            StockItemEntity item = new StockItemEntity("Item " + i, i, managerUser);
+            item.setStock(stock);
+            items.add(item);
+        }
+        stockItemRepository.saveAll(items);
+
+        Long stockId = stock.getId();
+
+        // Verify items exist before deletion
+        List<StockItemEntity> itemsBeforeDeletion = stockItemRepository.findByStockId(stockId);
+        assertEquals(10, itemsBeforeDeletion.size());
+
+        // When
+        stockService.deleteStockById(stockId);
+
+        // Then
+        Optional<StockEntity> deletedStock = stockRepository.findById(stockId);
+        assertFalse(deletedStock.isPresent());
+
+        // Verify all items are deleted
+        List<StockItemEntity> itemsAfterDeletion = stockItemRepository.findByStockId(stockId);
+        assertTrue(itemsAfterDeletion.isEmpty());
+    }
+
+    @Test
+    public void testDeleteStockById_UserNotAuthenticated() {
+        // Given - no security context
+        StockEntity stock = new StockEntity("Test Stock", colocation);
+        stock = stockRepository.save(stock);
+
+        // When & Then
+        final StockEntity finalStock = stock;
+        TechnicalException exception = assertThrows(TechnicalException.class,
+                                                    () -> stockService.deleteStockById(finalStock.getId()));
+
+        assertEquals(401, exception.getCode());
+        assertEquals("User is not authenticated", exception.getMessage());
+    }
+
+    @Test
+    public void testAddItemToStock_ExceedsCapacity() throws
+                                                     TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockEntity stock = new StockEntity("Frigo", colocation);
+        stock.setMaxCapacity(10);
+        stock = stockRepository.save(stock);
+
+        // Add existing item with quantity 8
+        StockItemEntity existingItem = new StockItemEntity("Lait", 8, managerUser);
+        existingItem.setStock(stock);
+        stockItemRepository.save(existingItem);
+
+        // Try to add new item with quantity 5 (total would be 13, exceeding max capacity of 10)
+        StockItemReqDto dto = new StockItemReqDto();
+        dto.setName("Fromage");
+        dto.setQuantity(5);
+
+        // When & Then
+        final StockEntity finalStock = stock;
+        TechnicalException exception = assertThrows(TechnicalException.class,
+                                                    () -> stockService.addItemToStock(colocation.getId(), finalStock.getId(), dto));
+
+        assertEquals(400, exception.getCode());
+        assertTrue(exception.getMessage()
+                            .contains("dépasserait la capacité maximale du stock"));
+        assertTrue(exception.getMessage()
+                            .contains("13"));
+        assertTrue(exception.getMessage()
+                            .contains("10"));
+    }
+
+    @Test
+    public void testAddItemToStock_ExactCapacity() throws
+                                                   TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockEntity stock = new StockEntity("Frigo", colocation);
+        stock.setMaxCapacity(10);
+        stock = stockRepository.save(stock);
+
+        // Add existing item with quantity 8
+        StockItemEntity existingItem = new StockItemEntity("Lait", 8, managerUser);
+        existingItem.setStock(stock);
+        stockItemRepository.save(existingItem);
+
+        // Add new item with quantity 2 (total would be exactly 10)
+        StockItemReqDto dto = new StockItemReqDto();
+        dto.setName("Fromage");
+        dto.setQuantity(2);
+
+        // When
+        StockItemResDto result = stockService.addItemToStock(colocation.getId(), stock.getId(), dto);
+
+        // Then
+        assertNotNull(result);
+        assertEquals("Fromage", result.getName());
+        assertEquals(2, result.getQuantity());
+    }
+
+    @Test
+    public void testAddItemToStock_NoCapacityLimit() throws
+                                                     TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockEntity stock = new StockEntity("Frigo", colocation);
+        stock.setMaxCapacity(null); // No capacity limit
+        stock = stockRepository.save(stock);
+
+        // Add large quantity item
+        StockItemReqDto dto = new StockItemReqDto();
+        dto.setName("Eau");
+        dto.setQuantity(1000);
+
+        // When
+        StockItemResDto result = stockService.addItemToStock(colocation.getId(), stock.getId(), dto);
+
+        // Then
+        assertNotNull(result);
+        assertEquals("Eau", result.getName());
+        assertEquals(1000, result.getQuantity());
+    }
+
+    @Test
+    public void testUpdateStockItem_ExceedsCapacity() throws
+                                                      TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockEntity stock = new StockEntity("Frigo", colocation);
+        stock.setMaxCapacity(10);
+        stock = stockRepository.save(stock);
+
+        // Add existing items
+        StockItemEntity item1 = new StockItemEntity("Lait", 3, managerUser);
+        item1.setStock(stock);
+        item1 = stockItemRepository.save(item1);
+
+        StockItemEntity item2 = new StockItemEntity("Fromage", 4, managerUser);
+        item2.setStock(stock);
+        stockItemRepository.save(item2);
+
+        // Try to update item1 to quantity 8 (total would be 8 + 4 = 12, exceeding max capacity of 10)
+        StockItemReqDto updateDto = new StockItemReqDto();
+        updateDto.setName("Lait");
+        updateDto.setQuantity(8);
+
+        // When & Then
+        final StockItemEntity finalItem1 = item1;
+        final StockEntity     finalStock = stock;
+        TechnicalException exception = assertThrows(TechnicalException.class,
+                                                    () -> stockService.updateStockItem(colocation.getId(), finalStock.getId(), finalItem1.getId(), updateDto));
+
+        assertEquals(400, exception.getCode());
+        assertTrue(exception.getMessage()
+                            .contains("dépasserait la capacité maximale du stock"));
+        assertTrue(exception.getMessage()
+                            .contains("12"));
+        assertTrue(exception.getMessage()
+                            .contains("10"));
+    }
+
+    @Test
+    public void testUpdateStockItem_WithinCapacity() throws
+                                                     TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockEntity stock = new StockEntity("Frigo", colocation);
+        stock.setMaxCapacity(10);
+        stock = stockRepository.save(stock);
+
+        // Add existing items
+        StockItemEntity item1 = new StockItemEntity("Lait", 3, managerUser);
+        item1.setStock(stock);
+        item1 = stockItemRepository.save(item1);
+
+        StockItemEntity item2 = new StockItemEntity("Fromage", 4, managerUser);
+        item2.setStock(stock);
+        stockItemRepository.save(item2);
+
+        // Update item1 to quantity 6 (total would be 6 + 4 = 10, exactly at max capacity)
+        StockItemReqDto updateDto = new StockItemReqDto();
+        updateDto.setName("Lait Bio");
+        updateDto.setQuantity(6);
+
+        // When
+        StockItemResDto result = stockService.updateStockItem(colocation.getId(), stock.getId(), item1.getId(), updateDto);
+
+        // Then
+        assertNotNull(result);
+        assertEquals("Lait Bio", result.getName());
+        assertEquals(6, result.getQuantity());
+    }
+
+    @Test
+    public void testUpdateStockItem_ReducingQuantity() throws
+                                                       TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockEntity stock = new StockEntity("Frigo", colocation);
+        stock.setMaxCapacity(10);
+        stock = stockRepository.save(stock);
+
+        // Add existing items that are at max capacity
+        StockItemEntity item1 = new StockItemEntity("Lait", 6, managerUser);
+        item1.setStock(stock);
+        item1 = stockItemRepository.save(item1);
+
+        StockItemEntity item2 = new StockItemEntity("Fromage", 4, managerUser);
+        item2.setStock(stock);
+        stockItemRepository.save(item2);
+
+        // Update item1 to reduce quantity to 2 (total would be 2 + 4 = 6, well under capacity)
+        StockItemReqDto updateDto = new StockItemReqDto();
+        updateDto.setName("Lait");
+        updateDto.setQuantity(2);
+
+        // When
+        StockItemResDto result = stockService.updateStockItem(colocation.getId(), stock.getId(), item1.getId(), updateDto);
+
+        // Then
+        assertNotNull(result);
+        assertEquals("Lait", result.getName());
+        assertEquals(2, result.getQuantity());
+    }
+
+    @Test
+    public void testAddItemToStock_NullQuantity() throws
+                                                  TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockEntity stock = new StockEntity("Frigo", colocation);
+        stock.setMaxCapacity(10);
+        stock = stockRepository.save(stock);
+
+        // Add item with null quantity (should be treated as 0)
+        StockItemReqDto dto = new StockItemReqDto();
+        dto.setName("Test Item");
+        dto.setQuantity(2);
+
+        // When
+        StockItemResDto result = stockService.addItemToStock(colocation.getId(), stock.getId(), dto);
+
+        // Then
+        assertNotNull(result);
+        assertEquals("Test Item", result.getName());
+        assertNotNull(result.getQuantity());
+        assertEquals(2, result.getQuantity());
+    }
+
+    @Test
+    public void testCapacityValidation_MultipleItemsAtCapacity() throws
+                                                                 TechnicalException {
+        // Given
+        this.initSecurityContextPlaceHolder();
+
+        StockEntity stock = new StockEntity("Frigo", colocation);
+        stock.setMaxCapacity(15);
+        stock = stockRepository.save(stock);
+
+        // Add multiple items totaling exactly 15
+        StockItemEntity item1 = new StockItemEntity("Item1", 5, managerUser);
+        item1.setStock(stock);
+        stockItemRepository.save(item1);
+
+        StockItemEntity item2 = new StockItemEntity("Item2", 7, managerUser);
+        item2.setStock(stock);
+        stockItemRepository.save(item2);
+
+        StockItemEntity item3 = new StockItemEntity("Item3", 3, managerUser);
+        item3.setStock(stock);
+        stockItemRepository.save(item3);
+
+        // Try to add one more item with quantity 1 (should fail)
+        StockItemReqDto dto = new StockItemReqDto();
+        dto.setName("Item4");
+        dto.setQuantity(1);
+
+        // When & Then
+        final StockEntity finalStock = stock;
+        TechnicalException exception = assertThrows(TechnicalException.class,
+                                                    () -> stockService.addItemToStock(colocation.getId(), finalStock.getId(), dto));
+
+        assertEquals(400, exception.getCode());
+        assertTrue(exception.getMessage()
+                            .contains("16"));
+        assertTrue(exception.getMessage()
+                            .contains("15"));
+    }
+}


### PR DESCRIPTION
  - Disable Elasticsearch in `application.yml`
  - Add DTOs with validation & Swagger: `StockReqDto`/`StockResDto`, `StockItemReqDto`/`StockItemResDto`
  - Update `TaskDocument` to include `assignedToUserKeycloakSubs`
  - Extend `Colocation` entity to manage `stocks` (add/remove)
  - Introduce `StockEntity` & `StockItemEntity` with relations and helper methods
  - Create `StockRepository` & `StockItemRepository` with custom queries
  - Add `StockRepositoryTest` & `StockItemRepositoryTest` for JPA repository coverage
  - Implement `StockRest` endpoints and `StockRestTest`
  - Implement `StockService` for stock/item CRUD and business rules