### PR TITLE
bump version dependencies

### DIFF
--- a/co-habit-project/co-habit-security/pom.xml
+++ b/co-habit-project/co-habit-security/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>fr.esgi</groupId>
@@ -16,7 +16,20 @@
         <maven.compiler.source>23</maven.compiler.source>
         <maven.compiler.target>23</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <keycloak.version>26.0.5</keycloak.version>
+        <spring-security.version>6.4.6</spring-security.version>
+        <spring.version>6.2.8</spring.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-crypto</artifactId>
+                <version>${spring-security.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -27,7 +40,7 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-admin-client</artifactId>
-            <version>${keycloak-admin-client}</version>
+            <version>${keycloak.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -40,10 +53,12 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-jose</artifactId>
+            <version>${spring-security.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
+            <version>${spring-security.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
@@ -63,14 +78,14 @@
             <version>3.6.0</version>
         </dependency>
 
-         <!-- Spring Test pour ReflectionTestUtils -->
+        <!-- Spring Test pour ReflectionTestUtils -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
 
-         <!-- OkHttp3 pour les tests -->
+        <!-- OkHttp3 pour les tests -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>

--- a/co-habit-project/pom.xml
+++ b/co-habit-project/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.3</version>
+        <version>3.4.6</version>
     </parent>
 
     <groupId>fr.esgi</groupId>
@@ -57,7 +57,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <keycloak-admin-client>22.0.1</keycloak-admin-client>
-        <spring.boot.version>3.4.3</spring.boot.version>
+        <spring.boot.version>3.4.6</spring.boot.version>
         <lombok.version>1.18.34</lombok.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <junit-jupiter.version>5.12.0</junit-jupiter.version>
@@ -66,10 +66,17 @@
         <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
         <swagger-annotations-jakarta>2.2.30</swagger-annotations-jakarta>
         <assertj.core>3.27.3</assertj.core>
+        <spring.version>6.2.8</spring.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-web</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
@@ -107,7 +114,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
-        
+
         <!-- JUnit 5 -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -154,7 +161,7 @@
                         <mainClass>fr.esgi.domain.CoHabitApplication</mainClass>
                     </configuration>
                 </plugin>
-                
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
@@ -167,7 +174,7 @@
                         </excludes>
                     </configuration>
                 </plugin>
-                
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
@@ -183,6 +190,39 @@
                             <goals>
                                 <goal>integration-test</goal>
                                 <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <!-- Security OWASP -->
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <version>12.1.1</version>
+                    <configuration>
+                        <failBuildOnCVSS>7</failBuildOnCVSS>
+                        <formats>
+                            <format>HTML</format>
+                            <format>XML</format>
+                            <format>JSON</format>
+                        </formats>
+                        <outputDirectory>${project.build.directory}/dependency-check</outputDirectory>
+                        <!-- Add NVD API Key configuration -->
+                        <!-- <nvdApiKey>54c1d3dd-****-****-****-ead991f45afe</nvdApiKey>-->
+                        <scanSet>
+                            <fileSet>
+                                <directory>${project.basedir}</directory>
+                                <includes>
+                                    <include>**/*.jar</include>
+                                </includes>
+                            </fileSet>
+                        </scanSet>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>check</goal>
                             </goals>
                         </execution>
                     </executions>


### PR DESCRIPTION
- Bump Spring Boot à 3.4.6 et Spring (Web, Security) à 6.2.8/6.4.6
- Centralise `spring-security-crypto` dans dependencyManagement
- Corrige la variable `${keycloak.version}` pour `keycloak-admin-client` (26.0.5)
- Ajoute le plugin OWASP Dependency-Check Maven (v12.1.1) avec seuil CVSS ≥ 7