### PR TITLE
bump driver version for postgresql

### DIFF
--- a/co-habit-project/pom.xml
+++ b/co-habit-project/pom.xml
@@ -67,6 +67,7 @@
         <swagger-annotations-jakarta>2.2.30</swagger-annotations-jakarta>
         <assertj.core>3.27.3</assertj.core>
         <spring.version>6.2.8</spring.version>
+        <postgresql.version>42.7.7</postgresql.version>
     </properties>
 
     <dependencyManagement>
@@ -90,6 +91,12 @@
                 <artifactId>lombok</artifactId>
                 <version>${lombok.version}</version>
                 <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${postgresql.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
- Ajoute la note de sécurité pour CVE-2025-49146(8.0)
- Déclare la propriété `postgresql.version` à `42.7.7`
- Ajoute la dépendance PostgreSQL dans `dependencyManagement`