### PR TITLE
bump version tomcat

### DIFF
--- a/co-habit-project/pom.xml
+++ b/co-habit-project/pom.xml
@@ -68,6 +68,7 @@
         <assertj.core>3.27.3</assertj.core>
         <spring.version>6.2.8</spring.version>
         <postgresql.version>42.7.7</postgresql.version>
+        <tomcat.version>11.0.8</tomcat.version>
     </properties>
 
     <dependencyManagement>
@@ -97,6 +98,13 @@
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>${postgresql.version}</version>
+            </dependency>
+
+            <!-- Override Tomcat to address potential vulnerabilities CVE-2025-48988(8.7)-->
+            <dependency>
+                <groupId>org.apache.tomcat.embed</groupId>
+                <artifactId>tomcat-embed-core</artifactId>
+                <version>${tomcat.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
  - Déclare `tomcat.version` à `11.0.8`
  - Override `tomcat-embed-core` en dependencyManagement pour corriger CVE-2025-48988