### PR TITLE
feature&refactor(task & api)

### DIFF
--- a/co-habit-project/co-habit-domain/src/main/java/fr/esgi/domain/DateUtils.java
+++ b/co-habit-project/co-habit-domain/src/main/java/fr/esgi/domain/DateUtils.java
@@ -1,4 +1,4 @@
-package fr.esgi.domain.util;
+package fr.esgi.domain;
 
 import fr.esgi.domain.exception.TechnicalException;
 
@@ -12,9 +12,9 @@ import java.time.format.DateTimeParseException;
  */
 public class DateUtils {
 
-    private static final String            DEFAULT_DATE_PATTERN     = "yyyy-MM-dd";
-    private static final String            DEFAULT_DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
-    private static final DateTimeFormatter DEFAULT_FORMATTER        = DateTimeFormatter.ofPattern(DEFAULT_DATE_PATTERN);
+    public static final  String            DEFAULT_DATE_PATTERN       = "yyyy-MM-dd";
+    public static final  String            DEFAULT_DATETIME_PATTERN   = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    private static final DateTimeFormatter DEFAULT_FORMATTER          = DateTimeFormatter.ofPattern(DEFAULT_DATE_PATTERN);
     private static final DateTimeFormatter DEFAULT_DATETIME_FORMATTER = DateTimeFormatter.ofPattern(DEFAULT_DATETIME_PATTERN);
 
     private DateUtils() {

--- a/co-habit-project/co-habit-domain/src/main/java/fr/esgi/domain/dto/task/TaskReqDto.java
+++ b/co-habit-project/co-habit-domain/src/main/java/fr/esgi/domain/dto/task/TaskReqDto.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
 import java.util.Set;
 
 @AllArgsConstructor
@@ -35,8 +34,8 @@ public class TaskReqDto {
     @Schema(description = "Priorité de la tâche", example = "HIGH")
     private TaskPriority priority;
     
-    @Schema(description = "Date d'échéance", example = "2025-12-31")
-    private LocalDateTime dueDate;
+    @Schema(description = "Date d'échéance", example = "2025-06-25T08:20:41.678Z")
+    private String dueDate;
     
     @Schema(description = "IDs des utilisateurs assignés")
     private Set<Long> assignedUserIds;

--- a/co-habit-project/co-habit-domain/src/main/java/fr/esgi/domain/dto/task/TaskStatus.java
+++ b/co-habit-project/co-habit-domain/src/main/java/fr/esgi/domain/dto/task/TaskStatus.java
@@ -2,6 +2,7 @@ package fr.esgi.domain.dto.task;
 
 public enum TaskStatus {
     TODO("À faire"),
+    PENDING("En attent"),
     IN_PROGRESS("En cours"),
     COMPLETED("Terminée"),
     CANCELLED("Annulée");

--- a/co-habit-project/co-habit-persistence/src/main/java/fr/esgi/persistence/document/TaskDocument.java
+++ b/co-habit-project/co-habit-persistence/src/main/java/fr/esgi/persistence/document/TaskDocument.java
@@ -82,6 +82,7 @@ public class TaskDocument {
 
     public enum TaskStatus {
         TODO,
+        PENDING,
         IN_PROGRESS,
         COMPLETED,
         CANCELLED

--- a/co-habit-project/co-habit-rest/src/main/java/fr/esgi/rest/interne/TaskRest.java
+++ b/co-habit-project/co-habit-rest/src/main/java/fr/esgi/rest/interne/TaskRest.java
@@ -1,0 +1,204 @@
+package fr.esgi.rest.interne;
+
+import fr.esgi.domain.dto.task.TaskReqDto;
+import fr.esgi.domain.dto.task.TaskResDto;
+import fr.esgi.domain.exception.TechnicalException;
+import fr.esgi.service.task.TaskService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController()
+@RequestMapping("/api/interne/collocations/{idCollocation}/tasks")
+@RequiredArgsConstructor
+@Tag(name = "Tasks", description = "Gestion des tâches de colocation")
+public class TaskRest {
+
+    private final TaskService taskService;
+
+    @Operation(
+            summary = "Créer une nouvelle tâche",
+            description = "Ajoute une nouvelle tâche à la colocation spécifiée"
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "201", description = "Tâche créée avec succès"),
+                    @ApiResponse(responseCode = "400", description = "Données de la tâche invalides"),
+                    @ApiResponse(responseCode = "401", description = "Utilisateur non authentifié"),
+                    @ApiResponse(responseCode = "403", description = "Accès refusé à cette colocation"),
+                    @ApiResponse(responseCode = "404", description = "Utilisateur ou colocation non trouvé")
+            }
+    )
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public TaskResDto createTask(
+            @Parameter(description = "ID de la colocation", required = true)
+            @PathVariable Long idCollocation,
+            @Parameter(description = "Données de la tâche à créer", required = true)
+            @RequestBody TaskReqDto dto) throws
+                                         TechnicalException {
+        return taskService.createTask(idCollocation, dto);
+    }
+
+    @Operation(
+            summary = "Obtenir toutes les tâches d'une colocation",
+            description = "Récupère la liste de toutes les tâches de la colocation spécifiée"
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Liste des tâches récupérée avec succès"),
+                    @ApiResponse(responseCode = "401", description = "Utilisateur non authentifié"),
+                    @ApiResponse(responseCode = "403", description = "Accès refusé à cette colocation"),
+                    @ApiResponse(responseCode = "404", description = "Utilisateur ou colocation non trouvé")
+            }
+    )
+    @GetMapping
+    public List<TaskResDto> getTasksByColocation(
+            @Parameter(description = "ID de la colocation", required = true)
+            @PathVariable Long idCollocation) throws
+                                              TechnicalException {
+        return taskService.getTasksByColocation(idCollocation);
+    }
+
+    @Operation(
+            summary = "Obtenir une tâche par son ID",
+            description = "Récupère les détails d'une tâche spécifique"
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Tâche récupérée avec succès"),
+                    @ApiResponse(responseCode = "401", description = "Utilisateur non authentifié"),
+                    @ApiResponse(responseCode = "403", description = "Accès refusé à cette tâche"),
+                    @ApiResponse(responseCode = "404", description = "Tâche non trouvée")
+            }
+    )
+    @GetMapping("/{taskId}")
+    public TaskResDto getTaskById(
+            @Parameter(description = "ID de la colocation", required = true)
+            @PathVariable Long idCollocation,
+            @Parameter(description = "ID de la tâche", required = true)
+            @PathVariable String taskId) throws
+                                         TechnicalException {
+        return taskService.getTaskById(taskId);
+    }
+
+    @Operation(
+            summary = "Mettre à jour une tâche",
+            description = "Modifie les informations d'une tâche existante"
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Tâche mise à jour avec succès"),
+                    @ApiResponse(responseCode = "400", description = "Données de la tâche invalides"),
+                    @ApiResponse(responseCode = "401", description = "Utilisateur non authentifié"),
+                    @ApiResponse(responseCode = "403", description = "Accès refusé à cette tâche"),
+                    @ApiResponse(responseCode = "404", description = "Tâche non trouvée")
+            }
+    )
+    @PutMapping("/{taskId}")
+    public TaskResDto updateTask(
+            @Parameter(description = "ID de la colocation", required = true)
+            @PathVariable Long idCollocation,
+            @Parameter(description = "ID de la tâche", required = true)
+            @PathVariable String taskId,
+            @Parameter(description = "Nouvelles données de la tâche", required = true)
+            @RequestBody TaskReqDto dto) throws
+                                         TechnicalException {
+        return taskService.updateTask(taskId, dto);
+    }
+
+    @Operation(
+            summary = "Assigner une tâche à un utilisateur",
+            description = "Assigne une tâche à un membre de la colocation"
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Tâche assignée avec succès"),
+                    @ApiResponse(responseCode = "401", description = "Utilisateur non authentifié"),
+                    @ApiResponse(responseCode = "403", description = "Accès refusé à cette tâche"),
+                    @ApiResponse(responseCode = "404", description = "Tâche ou utilisateur non trouvé")
+            }
+    )
+    @PatchMapping("/{taskId}/assign/{userId}")
+    public TaskResDto assignTask(
+            @Parameter(description = "ID de la colocation", required = true)
+            @PathVariable Long idCollocation,
+            @Parameter(description = "ID de la tâche", required = true)
+            @PathVariable String taskId,
+            @Parameter(description = "ID de l'utilisateur à assigner", required = true)
+            @PathVariable Long userId) throws
+                                       TechnicalException {
+        return taskService.assignTask(taskId, userId);
+    }
+
+    @Operation(
+            summary = "Marquer une tâche comme terminée",
+            description = "Change le statut d'une tâche à 'terminée'"
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Tâche marquée comme terminée"),
+                    @ApiResponse(responseCode = "401", description = "Utilisateur non authentifié"),
+                    @ApiResponse(responseCode = "403", description = "Accès refusé à cette tâche"),
+                    @ApiResponse(responseCode = "404", description = "Tâche non trouvée")
+            }
+    )
+    @PatchMapping("/{taskId}/complete")
+    public TaskResDto completeTask(
+            @Parameter(description = "ID de la colocation", required = true)
+            @PathVariable Long idCollocation,
+            @Parameter(description = "ID de la tâche", required = true)
+            @PathVariable String taskId) throws
+                                         TechnicalException {
+        return taskService.completeTask(taskId);
+    }
+
+    @Operation(
+            summary = "Supprimer une tâche",
+            description = "Supprime définitivement une tâche de la colocation"
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "204", description = "Tâche supprimée avec succès"),
+                    @ApiResponse(responseCode = "401", description = "Utilisateur non authentifié"),
+                    @ApiResponse(responseCode = "403", description = "Accès refusé à cette tâche"),
+                    @ApiResponse(responseCode = "404", description = "Tâche non trouvée")
+            }
+    )
+    @DeleteMapping("/{taskId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteTask(
+            @Parameter(description = "ID de la colocation", required = true)
+            @PathVariable Long idCollocation,
+            @Parameter(description = "ID de la tâche", required = true)
+            @PathVariable String taskId) throws
+                                         TechnicalException {
+        taskService.deleteTask(taskId);
+    }
+
+    @Operation(
+            summary = "Obtenir les tâches de l'utilisateur connecté",
+            description = "Récupère toutes les tâches assignées à l'utilisateur authentifié"
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "Tâches de l'utilisateur récupérées avec succès"),
+                    @ApiResponse(responseCode = "401", description = "Utilisateur non authentifié"),
+                    @ApiResponse(responseCode = "404", description = "Utilisateur non trouvé")
+            }
+    )
+    @GetMapping("/my-tasks")
+    public List<TaskResDto> getUserTasks(
+            @Parameter(description = "ID de la colocation", required = true)
+            @PathVariable Long idCollocation) throws
+                                              TechnicalException {
+        return taskService.getUserTasks();
+    }
+}

--- a/co-habit-project/co-habit-service/src/main/java/fr/esgi/service/registration/mapper/UserMapper.java
+++ b/co-habit-project/co-habit-service/src/main/java/fr/esgi/service/registration/mapper/UserMapper.java
@@ -1,8 +1,8 @@
 package fr.esgi.service.registration.mapper;
 
+import fr.esgi.domain.DateUtils;
 import fr.esgi.domain.dto.auth.RegisterReqDto;
 import fr.esgi.domain.dto.user.UserProfileResDto;
-import fr.esgi.domain.util.DateUtils;
 import fr.esgi.persistence.entity.user.User;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;

--- a/co-habit-project/co-habit-service/src/main/java/fr/esgi/service/space/UserRelationService.java
+++ b/co-habit-project/co-habit-service/src/main/java/fr/esgi/service/space/UserRelationService.java
@@ -1,10 +1,10 @@
 package fr.esgi.service.space;
 
+import fr.esgi.domain.DateUtils;
 import fr.esgi.domain.dto.user.UserRelationshipReqDto;
 import fr.esgi.domain.dto.user.UserRelationshipResDto;
 import fr.esgi.domain.exception.TechnicalException;
 import fr.esgi.domain.port.in.IUserRelationService;
-import fr.esgi.domain.util.DateUtils;
 import fr.esgi.persistence.entity.user.User;
 import fr.esgi.persistence.entity.user.UserRelationship;
 import fr.esgi.persistence.repository.user.UserRelationshipRepository;

--- a/co-habit-project/co-habit-service/src/main/java/fr/esgi/service/space/mapper/ColocationMapper.java
+++ b/co-habit-project/co-habit-service/src/main/java/fr/esgi/service/space/mapper/ColocationMapper.java
@@ -1,9 +1,9 @@
 package fr.esgi.service.space.mapper;
 
+import fr.esgi.domain.DateUtils;
 import fr.esgi.domain.dto.space.ColocationReqDto;
 import fr.esgi.domain.dto.space.ColocationResDto;
 import fr.esgi.domain.dto.user.UserProfileResDto;
-import fr.esgi.domain.util.DateUtils;
 import fr.esgi.persistence.entity.space.Colocation;
 import fr.esgi.persistence.entity.user.User;
 import org.mapstruct.Mapper;

--- a/co-habit-project/co-habit-service/src/main/java/fr/esgi/service/task/mapper/TaskMapper.java
+++ b/co-habit-project/co-habit-service/src/main/java/fr/esgi/service/task/mapper/TaskMapper.java
@@ -16,12 +16,12 @@ import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface TaskMapper {
-    
+
     TaskMapper INSTANCE = Mappers.getMapper(TaskMapper.class);
-    
+
     @Mapping(target = "createdAt", source = "createdAt", qualifiedByName = "localDateTimeToString")
     @Mapping(target = "completedAt", source = "completedAt", qualifiedByName = "localDateTimeToString")
-    @Mapping(target = "dueDate", source = "dueDate")
+    @Mapping(target = "dueDate", source = "dueDate", qualifiedByName = "localDateTimeToISOString")
     @Mapping(target = "assignedUsers", ignore = true)
     TaskResDto toTaskResDto(TaskDocument taskDocument);
     
@@ -37,11 +37,11 @@ public interface TaskMapper {
     @Mapping(target = "assignedToUserKeycloakSubs", ignore = true)
     @Mapping(target = "dueDate", source = "dueDate")
     TaskDocument toTaskDocument(TaskReqDto taskReqDto);
-    
+
     @Mapping(target = "assignedUsers", source = "assignedUsers")
     @Mapping(target = "dueDate", source = "taskDocument.dueDate", qualifiedByName = "localDateToLocalDateTime")
     TaskResDto toTaskResDtoWithUsers(TaskDocument taskDocument, List<UserProfileResDto> assignedUsers);
-    
+
     @Named("localDateTimeToString")
     default String localDateTimeToString(LocalDateTime dateTime) {
         if (dateTime == null) {
@@ -51,11 +51,11 @@ public interface TaskMapper {
     }
     
     @Named("localDateToLocalDateTime")
-    default LocalDateTime localDateToLocalDateTime(LocalDate date) {
+    default String localDateToLocalDateTime(LocalDate date) {
         if (date == null) {
             return null;
         }
-        return date.atStartOfDay();
+        return date.toString();
     }
     
     @Named("localDateTimeToLocalDate")
@@ -65,12 +65,22 @@ public interface TaskMapper {
         }
         return dateTime.toLocalDate();
     }
-    
+
+    @Named("localDateTimeToISOString")
+    default String localDateTimeToISOString(LocalDateTime dateTime) {
+        if (dateTime == null) {
+            return null;
+        }
+        return dateTime.toString();
+    }
+
     // Enum mappings
     default fr.esgi.domain.dto.task.TaskStatus mapStatus(TaskDocument.TaskStatus status) {
         if (status == null) return null;
         return fr.esgi.domain.dto.task.TaskStatus.valueOf(status.name());
     }
+
+
     
     default TaskDocument.TaskStatus mapStatus(fr.esgi.domain.dto.task.TaskStatus status) {
         if (status == null) return null;

--- a/co-habit-project/co-habit-service/src/test/java/fr/esgi/service/task/TaskServiceTest.java
+++ b/co-habit-project/co-habit-service/src/test/java/fr/esgi/service/task/TaskServiceTest.java
@@ -1,5 +1,6 @@
 package fr.esgi.service.task;
 
+import fr.esgi.domain.DateUtils;
 import fr.esgi.domain.dto.task.TaskReqDto;
 import fr.esgi.domain.dto.task.TaskResDto;
 import fr.esgi.domain.dto.task.TaskStatus;
@@ -174,8 +175,8 @@ public class TaskServiceTest extends AbstractTest {
         TaskReqDto dto = new TaskReqDto();
         dto.setTitle("Clean Kitchen");
         dto.setDescription("Clean all dishes and surfaces");
-        dto.setDueDate(LocalDateTime.now()
-                                    .plusDays(7));
+        dto.setDueDate(DateUtils.localDateTimeToString(LocalDateTime.now()
+                                                                    .plusDays(7)));
         dto.setStatus(TaskStatus.TODO);
 
         TaskDocument savedTask = new TaskDocument();

--- a/co-habit-project/co-habit-service/src/test/java/fr/esgi/service/task/mapper/TaskMapperTest.java
+++ b/co-habit-project/co-habit-service/src/test/java/fr/esgi/service/task/mapper/TaskMapperTest.java
@@ -58,7 +58,7 @@ class TaskMapperTest {
         assertEquals(TaskStatus.IN_PROGRESS, result.getStatus());
         assertEquals(TaskPriority.HIGH, result.getPriority());
         assertEquals("2025-01-15T10:30:00", result.getCreatedAt());
-        assertEquals(LocalDateTime.of(2025, 02, 01, 0, 0), result.getDueDate());
+        assertEquals("2025-02-01T00:00", result.getDueDate());
         assertEquals("2025-01-20T14:45:00", result.getCompletedAt());
         assertEquals(2L, result.getCreatorId());
         assertEquals(Set.of(1L, 2L), result.getAssignedUserIds());
@@ -74,7 +74,7 @@ class TaskMapperTest {
         taskReqDto.setDescription("New Description");
         taskReqDto.setStatus(TaskStatus.TODO);
         taskReqDto.setPriority(TaskPriority.MEDIUM);
-        taskReqDto.setDueDate(LocalDateTime.of(2025, 3, 15, 0, 0));
+        taskReqDto.setDueDate("2025-03-15T00:00:00.00");
         taskReqDto.setAssignedUserIds(Set.of(3L, 4L));
         taskReqDto.setTags(Set.of("shopping", "weekly"));
 
@@ -260,7 +260,7 @@ class TaskMapperTest {
         assertEquals(TaskStatus.CANCELLED, result.getStatus());
         assertEquals(TaskPriority.URGENT, result.getPriority());
         assertEquals("2025-01-01T12:00:00", result.getCreatedAt());
-        assertEquals(LocalDateTime.of(2025, 12, 31, 0, 0), result.getDueDate());
+        assertEquals("2025-12-31T00:00", result.getDueDate());
         assertEquals("2025-01-02T15:30:00", result.getCompletedAt());
         assertEquals(300L, result.getCreatorId());
         assertEquals(Set.of(100L, 200L, 300L), result.getAssignedUserIds());


### PR DESCRIPTION
  - DateUtils : rendre publics DEFAULT_DATE_PATTERN et DEFAULT_DATETIME_PATTERN
  - TaskReqDto : passer dueDate de `LocalDateTime` à `String` (ISO)
  - Ajout du statut `PENDING` dans TaskStatus (domain + document)
  - Création de `TaskRest` (CRUD + assign/complete/my-tasks) avec annotations Swagger
  - TaskMapper : utiliser `localDateTimeToISOString`, ajuster conversions date/heure
  - Mise à jour des tests (TaskServiceTest, TaskMapperTest) pour gérer le format String des dates
  - Harmonisation des imports de `DateUtils` dans les mappers